### PR TITLE
add: Cache response outside of CF worker

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -18,10 +18,12 @@ export default {
     }
 
     // TODO: Record retrieval stats to D1 asynchronously (do not block response)
-    const response = await retrieveFile(BASE_URL, pieceCid, env.CACHE_TTL)
+    let response = await retrieveFile(BASE_URL, pieceCid, env.CACHE_TTL)
     if (response.ok) {
+      response = new Response(response.body, response)
       response.headers.set('Cache-Control', `max-age=${env.CACHE_TTL}`)
     }
+
     return response
   }
 }

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -19,7 +19,9 @@ export default {
 
     // TODO: Record retrieval stats to D1 asynchronously (do not block response)
     const response = await retrieveFile(BASE_URL, pieceCid, env.CACHE_TTL)
-    response.headers.set('Cache-Control', `max-age=${env.CACHE_TTL}`)
+    if (response.ok) {
+      response.headers.set('Cache-Control', `max-age=${env.CACHE_TTL}`)
+    }
     return response
   }
 }

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -18,6 +18,8 @@ export default {
     }
 
     // TODO: Record retrieval stats to D1 asynchronously (do not block response)
-    return await retrieveFile(BASE_URL, pieceCid, env.CACHE_TTL)
+    const response = await retrieveFile(BASE_URL, pieceCid, env.CACHE_TTL)
+    response.headers.set('Cache-Control', `max-age=${env.CACHE_TTL}`)
+    return response
   }
 }


### PR DESCRIPTION
This pull request introduces caching response outside of CF worker by setting `Cache-Control` headers on response. Cache is performed only on successful response.