### PR TITLE
refactor: move CACHE_TTL config to git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           preCommands: './bin/pre-deploy.sh'
-          postCommands: |
-            rm -f wrangler.toml
           environment: production
-        env:
-          CACHE_TTL: ${{ vars.CACHE_TTL }}

--- a/bin/pre-deploy.sh
+++ b/bin/pre-deploy.sh
@@ -2,7 +2,6 @@
 
 PATH=./node_modules/.bin:$PATH
 
-envsubst < wrangler.toml > wrangler.toml.tmp && mv wrangler.toml.tmp wrangler.toml
 if ! wrangler d1 list | grep -q filcdn-db; then
   wrangler d1 create filcdn-db
 fi

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,7 +10,7 @@ DNS_ROOT = ".localhost"
 
 [env.production.vars]
 ENVIRONMENT = "production"
-CACHE_TTL = "$CACHE_TTL"
+CACHE_TTL = 86400
 DNS_ROOT = ".calibration.filcdn.io"
 
 [[d1_databases]]


### PR DESCRIPTION
Move the TTL configuration from GitHub-managed environmen variables to wrangler.toml versioned in git. This way we can keep track of changes made to this configuration.
