### PR TITLE
chore: fix `npm lint`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,5 +3,5 @@ import neostandard from 'neostandard'
 export default neostandard({
   noStyle: true, // Disable style-related rules, we use Prettier
   ts: true,
-  ignore: ['dist'],
+  ignores: ['dist', 'worker-configuration.d.ts'],
 })

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "description": "FilCDN Cloudflare Worker",
   "license": "MIT",
   "author": "Space Meridian <filcdn@meridian.space>",
+  "type": "module",
   "main": "bin/worker.js",
   "scripts": {
     "deploy": "wrangler deploy --env production",
     "deploy:dev": "wrangler deploy --env dev",
     "dev": "wrangler dev --env dev && wrangler d1 migrations apply filcdn-stats --local",
-    "lint": "eslint && prettier --check && tsc -p .",
+    "lint": "eslint && prettier --check . && tsc -p .",
     "lint:fix": "eslint --fix && prettier --write .",
     "start": "wrangler dev",
     "test": "vitest run"


### PR DESCRIPTION
We had bugs in the linter setup. As a result, the CI was not failing when the code did not pass all linters.
