### PR TITLE
test: fix flaky test assertion

### DIFF
--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -223,8 +223,8 @@ describe('worker.fetch', () => {
 
     assert.deepStrictEqual(result.client_address, defaultClientAddress)
     assert.strictEqual(result.response_status, 200)
-    assert.ok(result.fetch_ttfb > 0)
-    assert.ok(result.worker_ttfb > 0)
+    assert.strictEqual(typeof result.fetch_ttfb, 'number')
+    assert.strictEqual(typeof result.worker_ttfb, 'number')
   })
 })
 


### PR DESCRIPTION
Our code runs so fast that TTFB values are often `0`.

This commit changes the test assertions to accept such value.
