### PR TITLE
ci: run npm install before the wrangler step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm ci
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
Try to fix the following warnings:

[GitHub Actions workflow output](https://github.com/filcdn/worker/actions/runs/15349167669/job/43192744437#step:3:9)

```
/usr/local/bin/npx --no-install wrangler --version
  npm error npx canceled due to missing packages and no YES option: ["wrangler@4.18.0"]

(...)

  ▲ [WARNING] The version of Wrangler you are using is now out-of-date.
    Please update to the latest version to prevent critical errors.
    Run `npm install --save-dev wrangler@4` to update to the latest version.
    After installation, run Wrangler with `npx wrangler`.
   ⛅️ wrangler 3.90.0 (update available 4.18.0)
```

See https://github.com/cloudflare/wrangler-action/issues/286
