### PR TITLE
add: Request country code

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -19,9 +19,6 @@ export default {
   async fetch(request, env, ctx, { retrieveFile = defaultRetrieveFile } = {}) {
     const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
-    console.log(
-      `Retrieval request received at ${requestTimestamp} for ${request.url}`,
-    )
     const requestCountryCode = request.headers.get('CF-IPCountry')
     if (request.method !== 'GET') {
       return new Response('Method Not Allowed', { status: 405 })

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -19,7 +19,10 @@ export default {
   async fetch(request, env, ctx, { retrieveFile = defaultRetrieveFile } = {}) {
     const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
-
+    console.log(
+      `Retrieval request received at ${requestTimestamp} for ${request.url}`,
+    )
+    const requestCountryCode = request.headers.get('CF-IPCountry')
     if (request.method !== 'GET') {
       return new Response('Method Not Allowed', { status: 405 })
     }
@@ -59,6 +62,7 @@ export default {
           fetchTtfb,
           workerTtfb,
         },
+        requestCountryCode,
       }),
     )
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -13,6 +13,8 @@
  *   - Performance statistics.
  *
  * @param {string} params.timestamp - The timestamp of the retrieval.
+ * @param {string | null} params.requestCountryCode - The country code where the
+ *   request originated from
  * @returns {Promise<void>} - A promise that resolves when the log is inserted.
  */
 export async function logRetrievalResult(env, params) {
@@ -25,6 +27,7 @@ export async function logRetrievalResult(env, params) {
     responseStatus,
     timestamp,
     performanceStats,
+    requestCountryCode,
   } = params
 
   const egressBytes = contentLength ? parseInt(contentLength, 10) : 0
@@ -40,9 +43,10 @@ export async function logRetrievalResult(env, params) {
         egress_bytes,
         cache_miss,
         fetch_ttfb,
-        worker_ttfb
+        worker_ttfb,
+        request_country_code
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
     )
       .bind(
@@ -54,6 +58,7 @@ export async function logRetrievalResult(env, params) {
         cacheMiss,
         performanceStats?.fetchTtfb ?? null,
         performanceStats?.workerTtfb ?? null,
+        requestCountryCode,
       )
       .run()
   } catch (error) {

--- a/migrations/0003_add_request_country_code.sql
+++ b/migrations/0003_add_request_country_code.sql
@@ -1,0 +1,2 @@
+-- Migration number: 0003 	 2025-06-02T13:35:40.273Z
+ALTER TABLE retrieval_logs ADD request_country_code TEXT;

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -20,10 +20,11 @@ describe('logRetrievalResult', () => {
       contentLength: 1234,
       responseStatus: 200,
       timestamp: new Date().toISOString(),
+      requestCountryCode: 'US',
     })
 
     const readOutput = await env.DB.prepare(
-      `SELECT owner_address,client_address,response_status,egress_bytes,cache_miss FROM retrieval_logs WHERE owner_address = '${OWNER_ADDRESS}' AND client_address = '${CLIENT_ADDRESS}'`,
+      `SELECT owner_address,client_address,response_status,egress_bytes,cache_miss,request_country_code FROM retrieval_logs WHERE owner_address = '${OWNER_ADDRESS}' AND client_address = '${CLIENT_ADDRESS}'`,
     ).all()
     const result = readOutput.results
     assert.deepStrictEqual(result, [
@@ -33,6 +34,7 @@ describe('logRetrievalResult', () => {
         response_status: 200,
         egress_bytes: 1234,
         cache_miss: 0,
+        request_country_code: 'US',
       },
     ])
   })

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -226,7 +226,7 @@ describe('worker.fetch', () => {
     assert.strictEqual(typeof result.fetch_ttfb, 'number')
     assert.strictEqual(typeof result.worker_ttfb, 'number')
   })
-  it.only('stores requst country code in D1', async () => {
+  it('stores requst country code in D1', async () => {
     const mockRetrieveFile = async () => {
       return {
         response: new Response('file', {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -226,7 +226,7 @@ describe('worker.fetch', () => {
     assert.strictEqual(typeof result.fetch_ttfb, 'number')
     assert.strictEqual(typeof result.worker_ttfb, 'number')
   })
-  it('stores requst country code in D1', async () => {
+  it('stores request country code in D1', async () => {
     const mockRetrieveFile = async () => {
       return {
         response: new Response('file', {


### PR DESCRIPTION
This PR introduces recording of request origin country code. Country code should be present in the request headers as described in [Cloudflare docs](https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-ipcountry).

Related to:
- #28
- https://github.com/filcdn/dashboard/pull/7 