### PR TITLE
chore: fix vitest workspace setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "deploy:calibration": "npm run deploy:calibration --workspaces --if-present",
     "lint": "eslint && prettier --check . && tsc -p .",
     "lint:fix": "eslint --fix && prettier --write .",
-    "test": "npm test --workspaces --if-present"
+    "test": "wrangler d1 migrations apply test-db --local --cwd db && vitest run"
   },
   "prettier": "@checkernetwork/prettier-config",
   "devDependencies": {

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -1,7 +1,3 @@
-import { defineConfig } from 'vitest/config'
+import { defineWorkspace } from 'vitest/config'
 
-export default defineConfig({
-  test: {
-    projects: ['indexer', 'retriever'],
-  },
-})
+export default defineWorkspace(['indexer', 'retriever'])


### PR DESCRIPTION
I noticed that `npm t` runs vitest twice, which makes it difficult to spot test failures. This PR changes the vitest configuration to test all workspaces in one go.
