### PR TITLE
feat: fetch ProofSet owner from on-chain state

### DIFF
--- a/indexer/lib/pdp-verifier.js
+++ b/indexer/lib/pdp-verifier.js
@@ -52,7 +52,30 @@ export function createPdpVerifierClient({
     return rootCid.toString()
   }
 
-  return { getRootCid }
+  /**
+   * @param {BigInt} setId
+   * @returns {Promise<string>} The owner address in string format (`0x...`)
+   */
+  const getProofSetOwner = async (setId) => {
+    const result = await callEth({
+      rpcUrl,
+      authorization,
+      contractAddress: pdpVerifierAddress,
+      callData: pdpVerifierIface.encodeFunctionData('getProofSetOwner', [
+        setId,
+      ]),
+    })
+
+    const returnValues = pdpVerifierIface.decodeFunctionResult(
+      'getProofSetOwner',
+      result,
+    )
+
+    const [currentOwner /** , nextOwner */] = returnValues
+    return currentOwner
+  }
+
+  return { getRootCid, getProofSetOwner }
 }
 
 /**

--- a/indexer/lib/pdp-verifier.js
+++ b/indexer/lib/pdp-verifier.js
@@ -2,7 +2,11 @@ import { assertOkResponse } from 'assert-ok-response'
 import { Interface } from '@ethersproject/abi'
 import { CID } from 'multiformats/cid'
 
+// The ABI is based on the PDPVerifier source
+// https://github.com/FilOzone/pdp/blob/main/src/PDPVerifier.sol
 export const pdpVerifierAbi = [
+  // Returns the owner of a proof set and the proposed owner if any
+  'function getProofSetOwner(uint256 setId) public view returns (address, address)',
   // Returns the root CID for a given proof set and root ID
   'function getRootCid(uint256 setId, uint256 rootId) public view returns (tuple(bytes))',
 ]
@@ -27,41 +31,19 @@ export function createPdpVerifierClient({
    * @returns {Promise<string>} The CID in string format (`baga...`)
    */
   const getRootCid = async (setId, rootId) => {
-    const requestParams = {
-      to: pdpVerifierAddress,
-      data: pdpVerifierIface.encodeFunctionData('getRootCid', [setId, rootId]),
-    }
-
-    // TODO: add p-retry
-
-    const rpcResponse = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: {
-        authorization,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'eth_call',
-        params: [requestParams, 'latest'],
-      }),
+    const result = await callEth({
+      rpcUrl,
+      authorization,
+      contractAddress: pdpVerifierAddress,
+      callData: pdpVerifierIface.encodeFunctionData('getRootCid', [
+        setId,
+        rootId,
+      ]),
     })
-    await assertOkResponse(rpcResponse)
-
-    /** @type {any} */
-    const resBody = await rpcResponse.json()
-    if (resBody.error) {
-      throw new Error(`RPC error: ${JSON.stringify(resBody.error, null, 2)}`)
-    }
-    if (!resBody.result) {
-      throw new Error('RPC error: empty result.')
-    }
 
     const returnValues = pdpVerifierIface.decodeFunctionResult(
       'getRootCid',
-      resBody.result,
+      result,
     )
 
     const [[rootCidRaw]] = returnValues
@@ -71,4 +53,55 @@ export function createPdpVerifierClient({
   }
 
   return { getRootCid }
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.rpcUrl
+ * @param {string} params.authorization
+ * @param {string} params.contractAddress
+ * @param {string} params.callData
+ * @param {number | 'latest'} [params.blockNumber]
+ * @returns {Promise<string>}
+ */
+async function callEth({
+  rpcUrl,
+  authorization,
+  contractAddress,
+  callData,
+  blockNumber = 'latest',
+}) {
+  // TODO: add p-retry
+
+  const rpcResponse = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: {
+      authorization,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+      params: [
+        {
+          to: contractAddress,
+          data: callData,
+        },
+        blockNumber,
+      ],
+    }),
+  })
+  await assertOkResponse(rpcResponse)
+
+  /** @type {any} */
+  const resBody = await rpcResponse.json()
+  if (resBody.error) {
+    throw new Error(`RPC error: ${JSON.stringify(resBody.error, null, 2)}`)
+  }
+  if (!resBody.result) {
+    throw new Error('RPC error: empty result.')
+  }
+  return resBody.result
 }

--- a/indexer/test/pdp-verifier.test.js
+++ b/indexer/test/pdp-verifier.test.js
@@ -18,4 +18,16 @@ describe('PDPVerifier client', () => {
     )
     expect(cid).toBe(LIVE_PDP_FILE.cid)
   })
+
+  it('can fetch real ProofSet Owner', async () => {
+    const pdpVerifier = createPdpVerifierClient({
+      rpcUrl: env.RPC_URL,
+      glifToken: env.GLIF_TOKEN,
+      // Hard-coded to PDPVerifier deployed on calibration testnet
+      pdpVerifierAddress: '0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC',
+    })
+
+    const owner = await pdpVerifier.getProofSetOwner(LIVE_PDP_FILE.setId)
+    expect(owner).toBe(LIVE_PDP_FILE.owner)
+  })
 })

--- a/indexer/test/test-data.js
+++ b/indexer/test/test-data.js
@@ -5,4 +5,5 @@ export const LIVE_PDP_FILE = {
   setId: 126n,
   rootId: 0n,
   cid: 'baga6ea4seaqdmmx3vq7bf3oq3cxkwwh5ns5tk7cfhxuisa2qkmtdlpkpi3op2pq',
+  owner: '0x9f5087A1821eb3Ed8a137be368E5e451166EFAAe',
 }


### PR DESCRIPTION
- **refactor: extract callEth helper**
- **feat: fetch ProofSet owner from on-chain state**

Links:
- #54

This is a draft request, the most useful part is the first commit extracting the helper to make `eth_call` RPC requests. I think that refactoring did not go far enough, it would be even better if the helper could handle `encodeFunctionData` and `decodeFunctionResult` steps too.

**What's missing**
Integrate the new `getProofSetOwner` function into the webhook(s) + add tests.