### PR TITLE
retriever: Refactor error handling using `http-assert`-like fn. Closes #80

### DIFF
--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -6,6 +6,7 @@ import {
   measureStreamedEgress,
 } from '../lib/retrieval.js'
 import { getOwnerByRootCid, logRetrievalResult } from '../lib/store.js'
+import { httpAssert } from '../lib/http-assert.js'
 
 export default {
   /**
@@ -17,56 +18,63 @@ export default {
    * @returns
    */
   async fetch(request, env, ctx, { retrieveFile = defaultRetrieveFile } = {}) {
+    try {
+      return await this._fetch(request, env, ctx, retrieveFile)
+    } catch (error) {
+      console.error(error)
+      const message =
+        typeof error === 'object' &&
+        error !== null &&
+        'message' in error &&
+        typeof error.message === 'string'
+          ? error.message
+          : String(error)
+      const status =
+        typeof error === 'object' &&
+        error !== null &&
+        'status' in error &&
+        typeof error.status === 'number'
+          ? error.status
+          : 500
+      return new Response(message, { status })
+    }
+  },
+
+  /**
+   * @param {Request} request
+   * @param {Env} env
+   * @param {ExecutionContext} ctx
+   * @param {typeof defaultRetrieveFile} retrieveFile
+   * @returns
+   */
+  async _fetch(request, env, ctx, retrieveFile) {
     const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
     const requestCountryCode = request.headers.get('CF-IPCountry')
-    if (request.method !== 'GET') {
-      return new Response('Method Not Allowed', { status: 405 })
-    }
+    httpAssert(request.method === 'GET', 405, 'Method Not Allowed')
 
-    const {
-      clientWalletAddress,
-      rootCid,
-      error: parsingError,
-    } = parseRequest(request, env)
-    if (parsingError) {
-      console.error(parsingError)
-      return new Response(parsingError, { status: 400 })
-    }
+    const { clientWalletAddress, rootCid } = parseRequest(request, env)
 
-    if (!clientWalletAddress || !rootCid) {
-      return new Response('Missing required fields', { status: 400 })
-    }
-
-    if (!isValidEthereumAddress(clientWalletAddress)) {
-      return new Response(
-        `Invalid address: ${clientWalletAddress}. Address must be a valid ethereum address.`,
-        { status: 400 },
-      )
-    }
+    httpAssert(clientWalletAddress && rootCid, 400, 'Missing required fields')
+    httpAssert(
+      isValidEthereumAddress(clientWalletAddress),
+      400,
+      `Invalid address: ${clientWalletAddress}. Address must be a valid ethereum address.`,
+    )
 
     // Timestamp to measure file retrieval performance (from cache and from SP)
     const fetchStartedAt = performance.now()
-    const { ownerAddress, error: ownerLookupError } = await getOwnerByRootCid(
-      env,
-      rootCid,
-    )
-    if (ownerLookupError) {
-      console.error(ownerLookupError)
-      return new Response(ownerLookupError, { status: 404 })
-    }
+    const ownerAddress = await getOwnerByRootCid(env, rootCid)
 
-    if (
-      !ownerAddress ||
-      !Object.prototype.hasOwnProperty.call(
-        OWNER_TO_RETRIEVAL_URL_MAPPING,
-        ownerAddress,
-      )
-    ) {
-      const errorMessage = `Unsupported Storage Provider (PDP ProofSet Owner): ${ownerAddress}`
-      console.error(errorMessage)
-      return new Response(errorMessage, { status: 404 })
-    }
+    httpAssert(
+      ownerAddress &&
+        Object.prototype.hasOwnProperty.call(
+          OWNER_TO_RETRIEVAL_URL_MAPPING,
+          ownerAddress,
+        ),
+      404,
+      `Unsupported Storage Provider (PDP ProofSet Owner): ${ownerAddress}`,
+    )
     const spURL = OWNER_TO_RETRIEVAL_URL_MAPPING[ownerAddress].url
     const { response, cacheMiss } = await retrieveFile(
       spURL,

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -21,23 +21,7 @@ export default {
     try {
       return await this._fetch(request, env, ctx, retrieveFile)
     } catch (error) {
-      const errHasStatus =
-        typeof error === 'object' &&
-        error !== null &&
-        'status' in error &&
-        typeof error.status === 'number'
-      const message =
-        errHasStatus &&
-        error.status < 500 &&
-        'message' in error &&
-        typeof error.message === 'string'
-          ? error.message
-          : 'Internal Server Error'
-      const status = errHasStatus ? /** @type {number} */ (error.status) : 500
-      if (status >= 500) {
-        console.error(error)
-      }
-      return new Response(message, { status })
+      return this._handleError(error)
     }
   },
 
@@ -146,5 +130,31 @@ export default {
       statusText: response.statusText,
       headers: response.headers,
     })
+  },
+
+  /**
+   * @param {unknown} error
+   * @returns
+   */
+  _handleError(error) {
+    const errHasStatus =
+      typeof error === 'object' &&
+      error !== null &&
+      'status' in error &&
+      typeof error.status === 'number'
+
+    const status = errHasStatus ? /** @type {number} */ (error.status) : 500
+
+    const message =
+      errHasStatus &&
+      status < 500 &&
+      'message' in error &&
+      typeof error.message === 'string'
+        ? error.message
+        : 'Internal Server Error'
+    if (status >= 500) {
+      console.error(error)
+    }
+    return new Response(message, { status })
   },
 }

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -21,7 +21,6 @@ export default {
     try {
       return await this._fetch(request, env, ctx, retrieveFile)
     } catch (error) {
-      console.error(error)
       const errHasStatus =
         typeof error === 'object' &&
         error !== null &&
@@ -32,6 +31,9 @@ export default {
           ? error.message
           : 'Internal Server Error'
       const status = errHasStatus ? /** @type {number} */ (error.status) : 500
+      if (status >= 500) {
+        console.error(error)
+      }
       return new Response(message, { status })
     }
   },

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -27,7 +27,10 @@ export default {
         'status' in error &&
         typeof error.status === 'number'
       const message =
-        errHasStatus && error.status < 500 && 'message' in error && typeof error.message === 'string'
+        errHasStatus &&
+        error.status < 500 &&
+        'message' in error &&
+        typeof error.message === 'string'
           ? error.message
           : 'Internal Server Error'
       const status = errHasStatus ? /** @type {number} */ (error.status) : 500

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -22,20 +22,16 @@ export default {
       return await this._fetch(request, env, ctx, retrieveFile)
     } catch (error) {
       console.error(error)
-      const message =
-        typeof error === 'object' &&
-        error !== null &&
-        'message' in error &&
-        typeof error.message === 'string'
-          ? error.message
-          : String(error)
-      const status =
+      const errHasStatus =
         typeof error === 'object' &&
         error !== null &&
         'status' in error &&
         typeof error.status === 'number'
-          ? error.status
-          : 500
+      const message =
+        errHasStatus && 'message' in error && typeof error.message === 'string'
+          ? error.message
+          : 'Internal Server Error'
+      const status = errHasStatus ? /** @type {number} */ (error.status) : 500
       return new Response(message, { status })
     }
   },

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -27,7 +27,7 @@ export default {
         'status' in error &&
         typeof error.status === 'number'
       const message =
-        errHasStatus && 'message' in error && typeof error.message === 'string'
+        errHasStatus && error.status < 500 && 'message' in error && typeof error.message === 'string'
           ? error.message
           : 'Internal Server Error'
       const status = errHasStatus ? /** @type {number} */ (error.status) : 500

--- a/retriever/lib/http-assert.js
+++ b/retriever/lib/http-assert.js
@@ -1,0 +1,13 @@
+/**
+ * @param {any} condition
+ * @param {number} status
+ * @param {string} message
+ * @returns {asserts condition}
+ */
+export const httpAssert = (condition, status, message) => {
+  if (!condition) {
+    const error = new Error(message)
+    Object.assign(error, { status })
+    throw error
+  }
+}

--- a/retriever/lib/request.js
+++ b/retriever/lib/request.js
@@ -27,7 +27,7 @@ export function parseRequest(request, { DNS_ROOT }) {
   httpAssert(rootCid, 404, 'Missing required path element: `/{CID}`')
   httpAssert(
     rootCid.startsWith('baga'),
-    400,
+    404,
     `Invalid CID: ${rootCid}. It is not a valid CommP root.`,
   )
 

--- a/retriever/lib/request.js
+++ b/retriever/lib/request.js
@@ -24,7 +24,7 @@ export function parseRequest(request, { DNS_ROOT }) {
   const clientWalletAddress = url.hostname.slice(0, -DNS_ROOT.length)
   const [rootCid] = url.pathname.split('/').filter(Boolean)
 
-  httpAssert(rootCid, 400, 'Missing required path element: `/{CID}`')
+  httpAssert(rootCid, 404, 'Missing required path element: `/{CID}`')
   httpAssert(
     rootCid.startsWith('baga'),
     400,

--- a/retriever/lib/request.js
+++ b/retriever/lib/request.js
@@ -1,3 +1,5 @@
+import { httpAssert } from './http-assert.js'
+
 /**
  * Parse params found in path of the request URL
  *
@@ -7,28 +9,27 @@
  * @returns {{
  *   clientWalletAddress?: string
  *   rootCid?: string
- *   error?: string
  * }}
  */
 export function parseRequest(request, { DNS_ROOT }) {
   const url = new URL(request.url)
-  console.log({ msg: 'retrieval request', DNS_ROOT, url })
+  console.log('retrieval request', { DNS_ROOT, url })
 
-  if (!url.hostname.endsWith(DNS_ROOT)) {
-    return {
-      error: `Invalid hostname: ${url.hostname}. It must end with ${DNS_ROOT}.`,
-    }
-  }
+  httpAssert(
+    url.hostname.endsWith(DNS_ROOT),
+    400,
+    `Invalid hostname: ${url.hostname}. It must end with ${DNS_ROOT}.`,
+  )
+
   const clientWalletAddress = url.hostname.slice(0, -DNS_ROOT.length)
-
   const [rootCid] = url.pathname.split('/').filter(Boolean)
-  if (!rootCid) {
-    return { error: 'Missing required path element: `/{CID}`' }
-  }
 
-  if (!rootCid.startsWith('baga')) {
-    return { error: `Invalid CID: ${rootCid}. It is not a valid CommP root.` }
-  }
+  httpAssert(rootCid, 400, 'Missing required path element: `/{CID}`')
+  httpAssert(
+    rootCid.startsWith('baga'),
+    400,
+    `Invalid CID: ${rootCid}. It is not a valid CommP root.`,
+  )
 
   return { clientWalletAddress, rootCid }
 }

--- a/retriever/test/request.test.js
+++ b/retriever/test/request.test.js
@@ -26,16 +26,16 @@ describe('parseRequest', () => {
 
   it('should return descriptive error for missing rootCid', () => {
     const request = { url: `https://${TEST_WALLET}${DNS_ROOT}/` }
-    const result = parseRequest(request, { DNS_ROOT })
-    expect(result).toEqual({ error: 'Missing required path element: `/{CID}`' })
+    expect(() => parseRequest(request, { DNS_ROOT })).toThrowError(
+      'Missing required path element: `/{CID}`',
+    )
   })
 
   it('should return undefined for both if no params in path', () => {
     const request = { url: 'https://filcdn.io' }
-    const result = parseRequest(request, { DNS_ROOT })
-    expect(result).toEqual({
-      error: 'Invalid hostname: filcdn.io. It must end with .filcdn.io.',
-    })
+    expect(() => parseRequest(request, { DNS_ROOT })).toThrowError(
+      'Invalid hostname: filcdn.io. It must end with .filcdn.io.',
+    )
   })
 
   it('should ignore query parameters', () => {

--- a/retriever/test/store.test.js
+++ b/retriever/test/store.test.js
@@ -51,18 +51,17 @@ describe('getOwnerByRootCid', () => {
       .run()
 
     const result = await getOwnerByRootCid(env, rootCid)
-    assert.deepEqual(result, { ownerAddress: APPROVED_OWNER_ADDRESS })
+    assert.strictEqual(result, APPROVED_OWNER_ADDRESS)
   })
 
-  it('returns error if rootCid not found', async () => {
-    const result = await getOwnerByRootCid(env, 'nonexistent-cid')
-    assert.ok(
-      result.error.includes('does not exist'),
-      'Expected an error for missing root_cid',
+  it('throws error if rootCid not found', async () => {
+    await assert.rejects(
+      async () => await getOwnerByRootCid(env, 'nonexistent-cid'),
+      /does not exist/,
     )
   })
 
-  it('returns error if set_id exists but has no associated owner', async () => {
+  it('throws error if set_id exists but has no associated owner', async () => {
     const cid = 'cid-no-owner'
     const setId = 'set-no-owner'
 
@@ -75,15 +74,13 @@ describe('getOwnerByRootCid', () => {
       .bind('root-1', setId, cid)
       .run()
 
-    const result = await getOwnerByRootCid(env, cid)
-
-    assert.ok(
-      result.error.includes('no associated owner'),
-      'Expected error for set_id without an owner',
+    await assert.rejects(
+      async () => await getOwnerByRootCid(env, cid),
+      /no associated owner/,
     )
   })
 
-  it('returns error if owner exists but is not approved', async () => {
+  it('throws error if owner exists but is not approved', async () => {
     const cid = 'cid-unapproved'
     const setId = 'set-unapproved'
     const owner = '0x0000000000000000000000000000000000000000' // not in approved list
@@ -97,10 +94,9 @@ describe('getOwnerByRootCid', () => {
       ).bind('root-2', setId, cid),
     ])
 
-    const result = await getOwnerByRootCid(env, cid)
-    assert.ok(
-      result.error.includes('exists but has no approved owner'),
-      `Expected error for unapproved owner, received: ${JSON.stringify(result)}`,
+    await assert.rejects(
+      async () => await getOwnerByRootCid(env, cid),
+      /exists but has no approved owner/,
     )
   })
 
@@ -119,7 +115,7 @@ describe('getOwnerByRootCid', () => {
 
     const result = await getOwnerByRootCid(env, cid)
 
-    assert.deepEqual(result, { ownerAddress: APPROVED_OWNER_ADDRESS })
+    assert.strictEqual(result, APPROVED_OWNER_ADDRESS)
   })
   it('returns owner for valid rootCid with mixed-case owner (case insensitive)', async () => {
     const setId = 'test-set-1'
@@ -143,7 +139,7 @@ describe('getOwnerByRootCid', () => {
 
     // Lookup by rootCid and assert returned owner is normalized to lowercase
     const result = await getOwnerByRootCid(env, rootCid)
-    assert.deepEqual(result, { ownerAddress: expectedOwner })
+    assert.strictEqual(result, expectedOwner)
   })
 
   it('returns only the approved owner when multiple owners share the same rootCid', async () => {
@@ -181,8 +177,6 @@ describe('getOwnerByRootCid', () => {
 
     // Should return only the approved owner
     const result = await getOwnerByRootCid(env, rootCid, APPROVED_OWNER_ADDRESS)
-    assert.deepEqual(result, {
-      ownerAddress: APPROVED_OWNER_ADDRESS.toLowerCase(),
-    })
+    assert.strictEqual(result, APPROVED_OWNER_ADDRESS.toLowerCase())
   })
 })


### PR DESCRIPTION
Closes #80

Using language native errors instead of custom `{ error }` properties, which are easier to miss