### PR TITLE
chore: change TS setup to `module:preserve`

### DIFF
--- a/indexer/vitest.config.js
+++ b/indexer/vitest.config.js
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import {
   defineWorkersProject,
-  // @ts-ignore
   readD1Migrations,
 } from '@cloudflare/vitest-pool-workers/config'
 

--- a/retriever/vitest.config.js
+++ b/retriever/vitest.config.js
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import {
   defineWorkersProject,
-  // @ts-ignore
   readD1Migrations,
 } from '@cloudflare/vitest-pool-workers/config'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,9 @@
     "skipLibCheck": true,
     "lib": ["es2022"],
     "target": "es2022",
-    "module": "Node16",
-    "moduleResolution": "node16",
+    "module": "preserve",
+    "moduleResolution": "bundler",
 
-    // TODO
     "strict": true,
     "forceConsistentCasingInFileNames": true,
 


### PR DESCRIPTION
See the discussion in
https://github.com/filcdn/worker/pull/98#discussion_r2154727117.

Why this is ok:

- AFAIK, we are bundling our code both for uploading to Cloudflare and for running the tests.

- We use TypeScript only for type checks, the transpilation & bundling is performed by a different tool.

Docs: https://www.typescriptlang.org/docs/handbook/modules/reference.html#preserve

