### PR TITLE
feat: add papertrail logs

### DIFF
--- a/indexer/bin/indexer.js
+++ b/indexer/bin/indexer.js
@@ -3,7 +3,6 @@ import {
   handleProviderRemoved,
 } from '../lib/provider-events-handler.js'
 import { createPdpVerifierClient as defaultCreatePdpVerifierClient } from '../lib/pdp-verifier.js'
-import { create } from 'domain'
 import { createLogger } from '../../telemetry/papertrail.js'
 
 export default {

--- a/indexer/lib/provider-events-handler.js
+++ b/indexer/lib/provider-events-handler.js
@@ -1,5 +1,6 @@
 import { isValidEthereumAddress } from '../../retriever/lib/address'
 import validator from 'validator'
+import { PapertrailLogger } from '../../telemetry/papertrail'
 
 /**
  * Handles the /provider-registered webhook
@@ -7,12 +8,15 @@ import validator from 'validator'
  * @param {Env} env
  * @param {string} provider
  * @param {string} pieceRetrievalUrl
+ * @param {object} options
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger instance
  * @returns {Promise<Response>}
  */
 export async function handleProviderRegistered(
   env,
   provider,
   pieceRetrievalUrl,
+  { logger = console } = {},
 ) {
   if (
     !provider ||
@@ -21,7 +25,7 @@ export async function handleProviderRegistered(
     typeof pieceRetrievalUrl !== 'string' ||
     !isValidEthereumAddress(provider)
   ) {
-    console.error('Invalid provider registered payload', {
+    logger.error('Invalid provider registered payload', {
       provider,
       pieceRetrievalUrl,
     })
@@ -29,11 +33,11 @@ export async function handleProviderRegistered(
   }
 
   if (!validator.isURL(pieceRetrievalUrl)) {
-    console.error('Invalid Piece Retrieval URL', { pieceRetrievalUrl })
+    logger.error('Invalid Piece Retrieval URL', { pieceRetrievalUrl })
     return new Response('Bad Request', { status: 400 })
   }
 
-  console.log(
+  logger.log(
     `Provider registered (provider=${provider}, pieceRetrievalUrl=${pieceRetrievalUrl})`,
   )
 
@@ -58,19 +62,21 @@ export async function handleProviderRegistered(
  *
  * @param {Env} env
  * @param {string} provider
+ * @param {object} options
+ * @param {PapertrailLogger | Console } [options.logger] - An optional logger instance
  * @returns {Promise<Response>}
  */
-export async function handleProviderRemoved(env, provider) {
+export async function handleProviderRemoved(env, provider, { logger = console } = {}) {
   if (
     !provider ||
     typeof provider !== 'string' ||
     !isValidEthereumAddress(provider)
   ) {
-    console.error('Invalid provider removed payload', { provider })
+    logger.error('Invalid provider removed payload', { provider })
     return new Response('Bad Request', { status: 400 })
   }
 
-  console.log(`Provider removed (provider=${provider})`)
+  logger.log(`Provider removed (provider=${provider})`)
 
   /** @type {D1Result<Record<string, unknown>>} */
   const result = await env.DB.prepare(

--- a/indexer/lib/provider-events-handler.js
+++ b/indexer/lib/provider-events-handler.js
@@ -1,6 +1,6 @@
 import { isValidEthereumAddress } from '../../retriever/lib/address'
 import validator from 'validator'
-import { PapertrailLogger } from '../../telemetry/papertrail'
+/** @typedef {import('../../telemetry/papertrail.js').PapertrailLogger} PapertrailLogger */
 
 /**
  * Handles the /provider-registered webhook
@@ -9,7 +9,8 @@ import { PapertrailLogger } from '../../telemetry/papertrail'
  * @param {string} provider
  * @param {string} pieceRetrievalUrl
  * @param {object} options
- * @param {PapertrailLogger | Console} [options.logger] - An optional logger instance
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger
+ *   instance
  * @returns {Promise<Response>}
  */
 export async function handleProviderRegistered(
@@ -63,10 +64,15 @@ export async function handleProviderRegistered(
  * @param {Env} env
  * @param {string} provider
  * @param {object} options
- * @param {PapertrailLogger | Console } [options.logger] - An optional logger instance
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger
+ *   instance
  * @returns {Promise<Response>}
  */
-export async function handleProviderRemoved(env, provider, { logger = console } = {}) {
+export async function handleProviderRemoved(
+  env,
+  provider,
+  { logger = console } = {},
+) {
   if (
     !provider ||
     typeof provider !== 'string' ||

--- a/indexer/wrangler.toml
+++ b/indexer/wrangler.toml
@@ -16,6 +16,7 @@ database_id = "8cc92155-16f6-426a-b782-2965e0daf100"
 ENVIRONMENT = "dev"
 RPC_URL = "https://api.calibration.node.glif.io/"
 PDP_VERIFIER_ADDRESS = "0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC"
+SERVICE_NAME = "filcdn-indexer"
 
 [[env.dev.d1_databases]]
 binding = "DB"
@@ -26,6 +27,7 @@ database_id = "8cc92155-16f6-426a-b782-2965e0daf101"
 ENVIRONMENT = "calibration"
 RPC_URL = "https://api.calibration.node.glif.io/"
 PDP_VERIFIER_ADDRESS = "0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC"
+SERVICE_NAME = "filcdn-indexer"
 
 [[env.calibration.d1_databases]]
 binding = "DB"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "workspaces": [
         "indexer",
-        "retriever"
+        "retriever",
+        "telemetry"
       ],
       "devDependencies": {
         "@checkernetwork/prettier-config": "^1.0.1",
@@ -77,17 +78,18 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.8.48",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.8.48.tgz",
-      "integrity": "sha512-lKxO+s2hjbmQVcw/l3SC2jV10WWEkxKW8V1e4sPBDMdoT9EuteU7jSNIJeSTAb+aw3MHGLrzlE0dRi9WHiIAcw==",
+      "version": "0.8.49",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.8.49.tgz",
+      "integrity": "sha512-8xY2BvBF6fszQSVplS8EF2kpLaqzRMI+sL5t3FdU/EqDCv9pQJttneUwbjjBThG0nufg5ymTeUA4Bfli93qAEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "birpc": "0.2.14",
         "cjs-module-lexer": "^1.2.3",
         "devalue": "^4.3.0",
-        "miniflare": "4.20250617.4",
+        "miniflare": "4.20250617.5",
         "semver": "^7.7.1",
-        "wrangler": "4.22.0",
+        "wrangler": "4.23.0",
         "zod": "^3.22.3"
       },
       "peerDependencies": {
@@ -696,9 +698,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -712,9 +714,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -762,9 +764,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
-      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
+      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -787,14 +789,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -802,9 +804,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1721,9 +1723,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1813,9 +1815,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz",
-      "integrity": "sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
+      "integrity": "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==",
       "cpu": [
         "arm"
       ],
@@ -1827,9 +1829,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.0.tgz",
-      "integrity": "sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz",
+      "integrity": "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==",
       "cpu": [
         "arm64"
       ],
@@ -1841,9 +1843,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.0.tgz",
-      "integrity": "sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz",
+      "integrity": "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==",
       "cpu": [
         "arm64"
       ],
@@ -1855,9 +1857,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.0.tgz",
-      "integrity": "sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz",
+      "integrity": "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==",
       "cpu": [
         "x64"
       ],
@@ -1869,9 +1871,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.0.tgz",
-      "integrity": "sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz",
+      "integrity": "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==",
       "cpu": [
         "arm64"
       ],
@@ -1883,9 +1885,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.0.tgz",
-      "integrity": "sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz",
+      "integrity": "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==",
       "cpu": [
         "x64"
       ],
@@ -1897,9 +1899,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.0.tgz",
-      "integrity": "sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz",
+      "integrity": "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==",
       "cpu": [
         "arm"
       ],
@@ -1911,9 +1913,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.0.tgz",
-      "integrity": "sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz",
+      "integrity": "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==",
       "cpu": [
         "arm"
       ],
@@ -1925,9 +1927,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.0.tgz",
-      "integrity": "sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz",
+      "integrity": "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==",
       "cpu": [
         "arm64"
       ],
@@ -1939,9 +1941,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.0.tgz",
-      "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz",
+      "integrity": "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==",
       "cpu": [
         "arm64"
       ],
@@ -1953,9 +1955,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.0.tgz",
-      "integrity": "sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz",
+      "integrity": "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==",
       "cpu": [
         "loong64"
       ],
@@ -1967,9 +1969,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.0.tgz",
-      "integrity": "sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz",
+      "integrity": "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==",
       "cpu": [
         "ppc64"
       ],
@@ -1981,9 +1983,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.0.tgz",
-      "integrity": "sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz",
+      "integrity": "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==",
       "cpu": [
         "riscv64"
       ],
@@ -1995,9 +1997,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.0.tgz",
-      "integrity": "sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz",
+      "integrity": "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==",
       "cpu": [
         "riscv64"
       ],
@@ -2009,9 +2011,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.0.tgz",
-      "integrity": "sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz",
+      "integrity": "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==",
       "cpu": [
         "s390x"
       ],
@@ -2023,9 +2025,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
-      "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
+      "integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
       "cpu": [
         "x64"
       ],
@@ -2037,9 +2039,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.0.tgz",
-      "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz",
+      "integrity": "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==",
       "cpu": [
         "x64"
       ],
@@ -2051,9 +2053,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.0.tgz",
-      "integrity": "sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz",
+      "integrity": "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==",
       "cpu": [
         "arm64"
       ],
@@ -2065,9 +2067,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.0.tgz",
-      "integrity": "sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz",
+      "integrity": "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==",
       "cpu": [
         "ia32"
       ],
@@ -2079,9 +2081,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.0.tgz",
-      "integrity": "sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
+      "integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
       "cpu": [
         "x64"
       ],
@@ -2166,9 +2168,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
-      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
+      "version": "22.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.0.tgz",
+      "integrity": "sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2190,17 +2192,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz",
-      "integrity": "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
+      "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.34.1",
-        "@typescript-eslint/type-utils": "8.34.1",
-        "@typescript-eslint/utils": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/type-utils": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -2214,7 +2216,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.34.1",
+        "@typescript-eslint/parser": "^8.35.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -2230,16 +2232,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.1.tgz",
-      "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
+      "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.34.1",
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/typescript-estree": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2255,14 +2257,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
-      "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
+      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.34.1",
-        "@typescript-eslint/types": "^8.34.1",
+        "@typescript-eslint/tsconfig-utils": "^8.35.1",
+        "@typescript-eslint/types": "^8.35.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2277,14 +2279,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
-      "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1"
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2295,9 +2297,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
-      "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
+      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2312,14 +2314,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.1.tgz",
-      "integrity": "sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
+      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.34.1",
-        "@typescript-eslint/utils": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2336,9 +2338,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
-      "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2350,16 +2352,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
-      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.34.1",
-        "@typescript-eslint/tsconfig-utils": "8.34.1",
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1",
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2405,16 +2407,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
-      "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.34.1",
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/typescript-estree": "8.34.1"
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2429,13 +2431,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
-      "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/types": "8.35.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2447,9 +2449,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.9.0.tgz",
-      "integrity": "sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.10.1.tgz",
+      "integrity": "sha512-zohDKXT1Ok0yhbVGff4YAg9HUs5ietG5GpvJBPFSApZnGe7uf2cd26DRhKZbn0Be6xHUZrSzP+RAgMmzyc71EA==",
       "cpu": [
         "arm"
       ],
@@ -2461,9 +2463,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.9.0.tgz",
-      "integrity": "sha512-sG1NHtgXtX8owEkJ11yn34vt0Xqzi3k9TJ8zppDmyG8GZV4kVWw44FHwKwHeEFl07uKPeC4ZoyuQaGh5ruJYPA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.10.1.tgz",
+      "integrity": "sha512-tAN6k5UrTd4nicpA7s2PbjR/jagpDzAmvXFjbpTazUe5FRsFxVcBlS1F5Lzp5jtWU6bdiqRhSvd4X8rdpCffeA==",
       "cpu": [
         "arm64"
       ],
@@ -2475,9 +2477,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.9.0.tgz",
-      "integrity": "sha512-nJ9z47kfFnCxN1z/oYZS7HSNsFh43y2asePzTEZpEvK7kGyuShSl3RRXnm/1QaqFL+iP+BjMwuB+DYUymOkA5A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-+FCsag8WkauI4dQ50XumCXdfvDCZEpMUnvZDsKMxfOisnEklpDFXc6ThY0WqybBYZbiwR5tWcFaZmI0G6b4vrg==",
       "cpu": [
         "arm64"
       ],
@@ -2489,9 +2491,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.9.0.tgz",
-      "integrity": "sha512-TK+UA1TTa0qS53rjWn7cVlEKVGz2B6JYe0C++TdQjvWYIyx83ruwh0wd4LRxYBM5HeuAzXcylA9BH2trARXJTw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-qYKGGm5wk71ONcXTMZ0+J11qQeOAPz3nw6VtqrBUUELRyXFyvK8cHhHsLBFR4GHnilc2pgY1HTB2TvdW9wO26Q==",
       "cpu": [
         "x64"
       ],
@@ -2503,9 +2505,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.9.0.tgz",
-      "integrity": "sha512-6uZwzMRFcD7CcCd0vz3Hp+9qIL2jseE/bx3ZjaLwn8t714nYGwiE84WpaMCYjU+IQET8Vu/+BNAGtYD7BG/0yA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.10.1.tgz",
+      "integrity": "sha512-hOHMAhbvIQ63gkpgeNsXcWPSyvXH7ZEyeg254hY0Lp/hX8NdW+FsUWq73g9946Pc/BrcVI/I3C1cmZ4RCX9bNw==",
       "cpu": [
         "x64"
       ],
@@ -2517,9 +2519,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.9.0.tgz",
-      "integrity": "sha512-bPUBksQfrgcfv2+mm+AZinaKq8LCFvt5PThYqRotqSuuZK1TVKkhbVMS/jvSRfYl7jr3AoZLYbDkItxgqMKRkg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-6ds7+zzHJgTDmpe0gmFcOTvSUhG5oZukkt+cCsSb3k4Uiz2yEQB4iCRITX2hBwSW+p8gAieAfecITjgqCkswXw==",
       "cpu": [
         "arm"
       ],
@@ -2531,9 +2533,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.9.0.tgz",
-      "integrity": "sha512-uT6E7UBIrTdCsFQ+y0tQd3g5oudmrS/hds5pbU3h4s2t/1vsGWbbSKhBSCD9mcqaqkBwoqlECpUrRJCmldl8PA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.10.1.tgz",
+      "integrity": "sha512-P7A0G2/jW00diNJyFeq4W9/nxovD62Ay8CMP4UK9OymC7qO7rG1a8Upad68/bdfpIOn7KSp7Aj/6lEW3yyznAA==",
       "cpu": [
         "arm"
       ],
@@ -2545,9 +2547,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.9.0.tgz",
-      "integrity": "sha512-vdqBh911wc5awE2bX2zx3eflbyv8U9xbE/jVKAm425eRoOVv/VseGZsqi3A3SykckSpF4wSROkbQPvbQFn8EsA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-Cg6xzdkrpltcTPO4At+A79zkC7gPDQIgosJmVV8M104ImB6KZi1MrNXgDYIAfkhUYjPzjNooEDFRAwwPadS7ZA==",
       "cpu": [
         "arm64"
       ],
@@ -2559,9 +2561,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.9.0.tgz",
-      "integrity": "sha512-/8JFZ/SnuDr1lLEVsxsuVwrsGquTvT51RZGvyDB/dOK3oYK2UqeXzgeyq6Otp8FZXQcEYqJwxb9v+gtdXn03eQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-aNeg99bVkXa4lt+oZbjNRPC8ZpjJTKxijg/wILrJdzNyAymO2UC/HUK1UfDjt6T7U5p/mK24T3CYOi3/+YEQSA==",
       "cpu": [
         "arm64"
       ],
@@ -2573,9 +2575,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.9.0.tgz",
-      "integrity": "sha512-FkJjybtrl+rajTw4loI3L6YqSOpeZfDls4SstL/5lsP2bka9TiHUjgMBjygeZEis1oC8LfJTS8FSgpKPaQx2tQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.10.1.tgz",
+      "integrity": "sha512-ylz5ojeXrkPrtnzVhpCO+YegG63/aKhkoTlY8PfMfBfLaUG8v6m6iqrL7sBUKdVBgOB4kSTUPt9efQdA/Y3Z/w==",
       "cpu": [
         "ppc64"
       ],
@@ -2587,9 +2589,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.9.0.tgz",
-      "integrity": "sha512-w/NZfHNeDusbqSZ8r/hp8iL4S39h4+vQMc9/vvzuIKMWKppyUGKm3IST0Qv0aOZ1rzIbl9SrDeIqK86ZpUK37w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.10.1.tgz",
+      "integrity": "sha512-xcWyhmJfXXOxK7lvE4+rLwBq+on83svlc0AIypfe6x4sMJR+S4oD7n9OynaQShfj2SufPw2KJAotnsNb+4nN2g==",
       "cpu": [
         "riscv64"
       ],
@@ -2601,9 +2603,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.9.0.tgz",
-      "integrity": "sha512-bEPBosut8/8KQbUixPry8zg/fOzVOWyvwzOfz0C0Rw6dp+wIBseyiHKjkcSyZKv/98edrbMknBaMNJfA/UEdqw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.10.1.tgz",
+      "integrity": "sha512-mW9JZAdOCyorgi1eLJr4gX7xS67WNG9XNPYj5P8VuttK72XNsmdw9yhOO4tDANMgiLXFiSFaiL1gEpoNtRPw/A==",
       "cpu": [
         "riscv64"
       ],
@@ -2615,9 +2617,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.9.0.tgz",
-      "integrity": "sha512-LDtMT7moE3gK753gG4pc31AAqGUC86j3AplaFusc717EUGF9ZFJ356sdQzzZzkBk1XzMdxFyZ4f/i35NKM/lFA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.10.1.tgz",
+      "integrity": "sha512-NZGKhBy6xkJ0k09cWNZz4DnhBcGlhDd3W+j7EYoNvf5TSwj2K6kbmfqTWITEgkvjsMUjm1wsrc4IJaH6VtjyHQ==",
       "cpu": [
         "s390x"
       ],
@@ -2629,9 +2631,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.9.0.tgz",
-      "integrity": "sha512-WmFd5KINHIXj8o1mPaT8QRjA9HgSXhN1gl9Da4IZihARihEnOylu4co7i/yeaIpcfsI6sYs33cNZKyHYDh0lrA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-VsjgckJ0gNMw7p0d8In6uPYr+s0p16yrT2rvG4v2jUpEMYkpnfnCiALa9SWshbvlGjKQ98Q2x19agm3iFk8w8Q==",
       "cpu": [
         "x64"
       ],
@@ -2643,9 +2645,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.9.0.tgz",
-      "integrity": "sha512-CYuXbANW+WgzVRIl8/QvZmDaZxrqvOldOwlbUjIM4pQ46FJ0W5cinJ/Ghwa/Ng1ZPMJMk1VFdsD/XwmCGIXBWg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-idMnajMeejnaFi0Mx9UTLSYFDAOTfAEP7VjXNgxKApso3Eu2Njs0p2V95nNIyFi4oQVGFmIuCkoznAXtF/Zbmw==",
       "cpu": [
         "x64"
       ],
@@ -2657,9 +2659,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.9.0.tgz",
-      "integrity": "sha512-6Rp2WH0OoitMYR57Z6VE8Y6corX8C6QEMWLgOV6qXiJIeZ1F9WGXY/yQ8yDC4iTraotyLOeJ2Asea0urWj2fKQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.10.1.tgz",
+      "integrity": "sha512-7jyhjIRNFjzlr8x5pth6Oi9hv3a7ubcVYm2GBFinkBQKcFhw4nIs5BtauSNtDW1dPIGrxF0ciynCZqzxMrYMsg==",
       "cpu": [
         "wasm32"
       ],
@@ -2674,9 +2676,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.9.0.tgz",
-      "integrity": "sha512-rknkrTRuvujprrbPmGeHi8wYWxmNVlBoNW8+4XF2hXUnASOjmuC9FNF1tGbDiRQWn264q9U/oGtixyO3BT8adQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.10.1.tgz",
+      "integrity": "sha512-TY79+N+Gkoo7E99K+zmsKNeiuNJYlclZJtKqsHSls8We2iGhgxtletVsiBYie93MSTDRDMI8pkBZJlIJSZPrdA==",
       "cpu": [
         "arm64"
       ],
@@ -2688,9 +2690,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.9.0.tgz",
-      "integrity": "sha512-Ceymm+iBl+bgAICtgiHyMLz6hjxmLJKqBim8tDzpX61wpZOx2bPK6Gjuor7I2RiUynVjvvkoRIkrPyMwzBzF3A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.10.1.tgz",
+      "integrity": "sha512-BAJN5PEPlEV+1m8+PCtFoKm3LQ1P57B4Z+0+efU0NzmCaGk7pUaOxuPgl+m3eufVeeNBKiPDltG0sSB9qEfCxw==",
       "cpu": [
         "ia32"
       ],
@@ -2702,9 +2704,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.0.tgz",
-      "integrity": "sha512-k59o9ZyeyS0hAlcaKFezYSH2agQeRFEB7KoQLXl3Nb3rgkqT1NY9Vwy+SqODiLmYnEjxWJVRE/yq2jFVqdIxZw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-2v3erKKmmCyIVvvhI2nF15qEbdBpISTq44m9pyd5gfIJB1PN94oePTLWEd82XUbIbvKhv76xTSeUQSCOGesLeg==",
       "cpu": [
         "x64"
       ],
@@ -3684,9 +3686,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
+      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3937,20 +3939,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
-      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
+      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.1",
-        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.29.0",
+        "@eslint/js": "9.30.1",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -4015,14 +4017,14 @@
       }
     },
     "node_modules/eslint-import-context": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.8.tgz",
-      "integrity": "sha512-bq+F7nyc65sKpZGT09dY0S0QrOnQtuDVIfyTGQ8uuvtMIF7oHp6CEP3mouN0rrnYF3Jqo6Ke0BfU/5wASZue1w==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-tsconfig": "^4.10.1",
-        "stable-hash-x": "^0.1.1"
+        "stable-hash-x": "^0.2.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -4097,21 +4099,21 @@
       }
     },
     "node_modules/eslint-plugin-import-x": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.15.2.tgz",
-      "integrity": "sha512-J5gx7sN6DTm0LRT//eP3rVVQ2Yi4hrX0B+DbWxa5er8PZ6JjLo9GUBwogIFvEDdwJaSqZplpQT+haK/cXhb7VQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
+      "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/types": "^8.35.0",
         "comment-parser": "^1.4.1",
         "debug": "^4.4.1",
-        "eslint-import-context": "^0.1.8",
+        "eslint-import-context": "^0.1.9",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.3 || ^10.0.1",
         "semver": "^7.7.2",
-        "stable-hash-x": "^0.1.1",
-        "unrs-resolver": "^1.9.0"
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4409,9 +4411,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.6.tgz",
-      "integrity": "sha512-Q05uIdxhPBVBwK29gcPsl2K220xSBy52TZQPdeYWE0zOs8jM+yJ6y5h7jm6cpAo1p+OOMZRIj/Ftku4EQQBLnQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6143,9 +6145,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250617.4",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250617.4.tgz",
-      "integrity": "sha512-IAoApFKxOJlaaFkym5ETstVX3qWzVt3xyqCDj6vSSTgEH3zxZJ5417jZGg8iQfMHosKCcQH1doPPqqnOZm/yrw==",
+      "version": "4.20250617.5",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250617.5.tgz",
+      "integrity": "sha512-Qqn30jR6dCjXaKVizT6vH4KOb+GyLccoxLNOJEfu63yBPn8eoXa7PrdiSGTmjs2RY8/tr7eTO8Wu/Yr14k0xVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6260,9 +6262,9 @@
       }
     },
     "node_modules/napi-postinstall": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
-      "integrity": "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.0.tgz",
+      "integrity": "sha512-M7NqKyhODKV1gRLdkwE7pDsZP2/SC2a2vHkOYh9MCpKMbWVfyVfUw5MaH83Fv6XMjxr5jryUp3IDDL9rlxsTeA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6565,9 +6567,9 @@
       "license": "MIT"
     },
     "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6659,6 +6661,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6670,9 +6673,9 @@
       }
     },
     "node_modules/prettier-plugin-jsdoc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.3.2.tgz",
-      "integrity": "sha512-LNi9eq0TjyZn/PUNf/SYQxxUvGg5FLK4alEbi3i/S+2JbMyTu790c/puFueXzx09KP44oWCJ+TaHRyM/a0rKJQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.3.3.tgz",
+      "integrity": "sha512-YIxejcbPYK4N58jHGiXjYvrCzBMyvV2AEMSoF5LvqqeMEI0nsmww57I6NGnpVc0AU9ncFCTEBoYHN/xuBf80YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6688,13 +6691,13 @@
       }
     },
     "node_modules/prettier-plugin-packagejson": {
-      "version": "2.5.15",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.15.tgz",
-      "integrity": "sha512-2QSx6y4IT6LTwXtCvXAopENW5IP/aujC8fobEM2pDbs0IGkiVjW/ipPuYAHuXigbNe64aGWF7vIetukuzM3CBw==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.17.tgz",
+      "integrity": "sha512-1WYvhTix+4EMYZQYSjAxb6+KTCULINuHUTBcxYa2ipoUS9Y2zJVjE3kuZ5I7ZWIFqyK8xpwYIunXqN5eiT7Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "sort-package-json": "3.2.1",
+        "sort-package-json": "3.3.1",
         "synckit": "0.11.8"
       },
       "peerDependencies": {
@@ -6859,9 +6862,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
-      "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
+      "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6875,26 +6878,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.44.0",
-        "@rollup/rollup-android-arm64": "4.44.0",
-        "@rollup/rollup-darwin-arm64": "4.44.0",
-        "@rollup/rollup-darwin-x64": "4.44.0",
-        "@rollup/rollup-freebsd-arm64": "4.44.0",
-        "@rollup/rollup-freebsd-x64": "4.44.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.44.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.44.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.44.0",
-        "@rollup/rollup-linux-arm64-musl": "4.44.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.44.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.44.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.44.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.44.0",
-        "@rollup/rollup-linux-x64-gnu": "4.44.0",
-        "@rollup/rollup-linux-x64-musl": "4.44.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.44.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.44.0",
-        "@rollup/rollup-win32-x64-msvc": "4.44.0",
+        "@rollup/rollup-android-arm-eabi": "4.44.1",
+        "@rollup/rollup-android-arm64": "4.44.1",
+        "@rollup/rollup-darwin-arm64": "4.44.1",
+        "@rollup/rollup-darwin-x64": "4.44.1",
+        "@rollup/rollup-freebsd-arm64": "4.44.1",
+        "@rollup/rollup-freebsd-x64": "4.44.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.44.1",
+        "@rollup/rollup-linux-arm64-musl": "4.44.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.44.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-musl": "4.44.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.44.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.44.1",
+        "@rollup/rollup-win32-x64-msvc": "4.44.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -7205,9 +7208,9 @@
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.2.1.tgz",
-      "integrity": "sha512-rTfRdb20vuoAn7LDlEtCqOkYfl2X+Qze6cLbNOzcDpbmKEhJI30tTN44d5shbKJnXsvz24QQhlCm81Bag7EOKg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.3.1.tgz",
+      "integrity": "sha512-awjhQR2Iy5UN3NuguAK5+RezcEuUg9Ra4O8y2Aj+DlJa7MywyHaipAPf9bu4qqFj0hsYHHoT9sS3aV7Ucu728g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7221,6 +7224,9 @@
       },
       "bin": {
         "sort-package-json": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/source-map": {
@@ -7251,9 +7257,9 @@
       "license": "MIT"
     },
     "node_modules/stable-hash-x": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.1.1.tgz",
-      "integrity": "sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7722,15 +7728,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.1.tgz",
-      "integrity": "sha512-XjS+b6Vg9oT1BaIUfkW3M3LvqZE++rbzAMEHuccCfO/YkP43ha6w3jTEMilQxMF92nVOYCcdjv1ZUhAa1D/0ow==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.35.1.tgz",
+      "integrity": "sha512-xslJjFzhOmHYQzSB/QTeASAHbjmxOGEP6Coh93TXmUBFQoJ1VU35UHIDmG06Jd6taf3wqqC1ntBnCMeymy5Ovw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.34.1",
-        "@typescript-eslint/parser": "8.34.1",
-        "@typescript-eslint/utils": "8.34.1"
+        "@typescript-eslint/eslint-plugin": "8.35.1",
+        "@typescript-eslint/parser": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7819,38 +7825,38 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.9.0.tgz",
-      "integrity": "sha512-wqaRu4UnzBD2ABTC1kLfBjAqIDZ5YUTr/MLGa7By47JV1bJDSW7jq/ZSLigB7enLe7ubNaJhtnBXgrc/50cEhg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.10.1.tgz",
+      "integrity": "sha512-EFrL7Hw4kmhZdwWO3dwwFJo6hO3FXuQ6Bg8BK/faHZ9m1YxqBS31BNSTxklIQkxK/4LlV8zTYnPsIRLBzTzjCA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.2.2"
+        "napi-postinstall": "^0.3.0"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.9.0",
-        "@unrs/resolver-binding-android-arm64": "1.9.0",
-        "@unrs/resolver-binding-darwin-arm64": "1.9.0",
-        "@unrs/resolver-binding-darwin-x64": "1.9.0",
-        "@unrs/resolver-binding-freebsd-x64": "1.9.0",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.9.0",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.9.0",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.9.0",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.9.0",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-x64-musl": "1.9.0",
-        "@unrs/resolver-binding-wasm32-wasi": "1.9.0",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.9.0",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.9.0",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.9.0"
+        "@unrs/resolver-binding-android-arm-eabi": "1.10.1",
+        "@unrs/resolver-binding-android-arm64": "1.10.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.10.1",
+        "@unrs/resolver-binding-darwin-x64": "1.10.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.10.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.10.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.10.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.10.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.10.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.10.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.10.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.10.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.10.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.10.1"
       }
     },
     "node_modules/uri-js": {
@@ -8255,16 +8261,17 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.22.0.tgz",
-      "integrity": "sha512-m8qVO3YxhUTII+4U889G/f5UuLSvMkUkCNatupV2f/SJ+iqaWtP1QbuQII8bs2J/O4rqxsz46Wu2S50u7tKB5Q==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.23.0.tgz",
+      "integrity": "sha512-JSeDt3IwA4TEmg/V3tRblImPjdxynBt9PUVO/acQJ83XGlMMSwswDKL1FuwvbFzgX6+JXc3GMHeu7r8AQIxw9w==",
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
         "@cloudflare/unenv-preset": "2.3.3",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20250617.4",
+        "miniflare": "4.20250617.5",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.17",
         "workerd": "1.20250617.0"
@@ -8802,9 +8809,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.71",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
+      "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "workspaces": [
     "indexer",
-    "retriever"
+    "retriever",
+    "telemetry"
   ],
   "scripts": {
     "build:types": "npm run build:types --workspaces --if-present",

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -38,7 +38,7 @@ export default {
         logger,
       })
     } catch (error) {
-      return this._handleError(error, env, { logger })
+      return this._handleError(error, { logger })
     }
   },
 
@@ -166,12 +166,11 @@ export default {
 
   /**
    * @param {unknown} error
-   * @param {Env} env
    * @param {object} options
    * @param {PapertrailLogger | Console} [options.logger]
    * @returns
    */
-  _handleError(error, env, { logger = createLogger(env) } = {}) {
+  _handleError(error, { logger = console } = {}) {
     const errHasStatus =
       typeof error === 'object' &&
       error !== null &&

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -12,7 +12,7 @@ import {
 } from '../lib/store.js'
 import { httpAssert } from '../lib/http-assert.js'
 import { createLogger } from '../../telemetry/papertrail.js'
-import { PapertrailLogger } from '../../telemetry/papertrail.js'
+/** @typedef {import('../../telemetry/papertrail.js').PapertrailLogger} PapertrailLogger */
 
 export default {
   /**
@@ -32,7 +32,11 @@ export default {
   ) {
     const logger = createLogger(env)
     try {
-      return await this._fetch(request, env, ctx, { retrieveFile, signal, logger })
+      return await this._fetch(request, env, ctx, {
+        retrieveFile,
+        signal,
+        logger,
+      })
     } catch (error) {
       return this._handleError(error, env, { logger })
     }
@@ -75,7 +79,7 @@ export default {
       env,
       clientWalletAddress,
       rootCid,
-      { logger }
+      { logger },
     )
 
     httpAssert(
@@ -178,9 +182,9 @@ export default {
 
     const message =
       errHasStatus &&
-        status < 500 &&
-        'message' in error &&
-        typeof error.message === 'string'
+      status < 500 &&
+      'message' in error &&
+      typeof error.message === 'string'
         ? error.message
         : 'Internal Server Error'
     if (status >= 500) {

--- a/retriever/lib/request.js
+++ b/retriever/lib/request.js
@@ -1,3 +1,4 @@
+import { createLogger, PapertrailLogger } from '../../telemetry/papertrail.js'
 import { httpAssert } from './http-assert.js'
 
 /**
@@ -6,14 +7,15 @@ import { httpAssert } from './http-assert.js'
  * @param {Request} request
  * @param {object} options
  * @param {string} options.DNS_ROOT
+ * @param {PapertrailLogger | Console} [options.logger]
  * @returns {{
  *   clientWalletAddress?: string
  *   rootCid?: string
  * }}
  */
-export function parseRequest(request, { DNS_ROOT }) {
+export function parseRequest(request, { DNS_ROOT, logger = console }) {
   const url = new URL(request.url)
-  console.log('retrieval request', { DNS_ROOT, url })
+  logger.log('retrieval request', { DNS_ROOT, url })
 
   httpAssert(
     url.hostname.endsWith(DNS_ROOT),

--- a/retriever/lib/request.js
+++ b/retriever/lib/request.js
@@ -1,5 +1,5 @@
-import { createLogger, PapertrailLogger } from '../../telemetry/papertrail.js'
 import { httpAssert } from './http-assert.js'
+/** @typedef {import('../../telemetry/papertrail.js').PapertrailLogger} PapertrailLogger */
 
 /**
  * Parse params found in path of the request URL

--- a/retriever/lib/retrieval.js
+++ b/retriever/lib/retrieval.js
@@ -1,3 +1,8 @@
+import {
+  PapertrailLogger
+} from "../../telemetry/papertrail"
+import { createLogger } from "../../telemetry/papertrail.js"
+
 /**
  * Retrieves the file under the pieceCID from the constructed URL.
  *
@@ -7,6 +12,7 @@
  *   Default is `86400`
  * @param {object} [options] - Optional parameters.
  * @param {AbortSignal} [options.signal] - An optional AbortSignal to cancel the
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger instance
  *   fetch request.
  * @returns {Promise<{
  *   response: Response
@@ -19,7 +25,7 @@ export async function retrieveFile(
   baseUrl,
   pieceCid,
   cacheTtl = 86400,
-  { signal } = {},
+  { signal, logger = console } = {},
 ) {
   const url = `${baseUrl}/piece/${pieceCid}`
   const response = await fetch(url, {
@@ -35,7 +41,7 @@ export async function retrieveFile(
   })
   const cacheStatus = response.headers.get('CF-Cache-Status')
   if (!cacheStatus) {
-    console.log(`CF-Cache-Status was not provided for ${url}`)
+    logger.log(`CF-Cache-Status was not provided for ${url}`)
   }
 
   const cacheMiss = cacheStatus !== 'HIT'

--- a/retriever/lib/retrieval.js
+++ b/retriever/lib/retrieval.js
@@ -1,7 +1,4 @@
-import {
-  PapertrailLogger
-} from "../../telemetry/papertrail"
-import { createLogger } from "../../telemetry/papertrail.js"
+/** @typedef {import('../../telemetry/papertrail.js').PapertrailLogger} PapertrailLogger */
 
 /**
  * Retrieves the file under the pieceCID from the constructed URL.
@@ -12,8 +9,8 @@ import { createLogger } from "../../telemetry/papertrail.js"
  *   Default is `86400`
  * @param {object} [options] - Optional parameters.
  * @param {AbortSignal} [options.signal] - An optional AbortSignal to cancel the
- * @param {PapertrailLogger | Console} [options.logger] - An optional logger instance
- *   fetch request.
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger
+ *   instance fetch request.
  * @returns {Promise<{
  *   response: Response
  *   cacheMiss: null | boolean

--- a/retriever/lib/store.js
+++ b/retriever/lib/store.js
@@ -1,5 +1,5 @@
 import { httpAssert } from './http-assert.js'
-import { createLogger, PapertrailLogger } from '../../telemetry/papertrail.js'
+/** @typedef {import('../../telemetry/papertrail.js').PapertrailLogger} PapertrailLogger */
 /**
  * Logs the result of a file retrieval attempt to the D1 database.
  *
@@ -18,10 +18,15 @@ import { createLogger, PapertrailLogger } from '../../telemetry/papertrail.js'
  * @param {string | null} params.requestCountryCode - The country code where the
  *   request originated from
  * @param {object} [options] - Optional parameters.
- * @param {PapertrailLogger | Console} [options.logger] - An optional logger instance
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger
+ *   instance
  * @returns {Promise<void>} - A promise that resolves when the log is inserted.
  */
-export async function logRetrievalResult(env, params, { logger = console } = {}) {
+export async function logRetrievalResult(
+  env,
+  params,
+  { logger = console } = {},
+) {
   logger.log('retrieval log', params)
   const {
     ownerAddress,
@@ -79,11 +84,17 @@ export async function logRetrievalResult(env, params, { logger = console } = {})
  * @param {string} clientAddress - The address of the client making the request
  * @param {string} rootCid - The root CID to look up
  * @param {object} [options] - Optional parameters
- * @param {PapertrailLogger | Console} [options.logger] - An optional logger instance
+ * @param {PapertrailLogger | Console} [options.logger] - An optional logger
+ *   instance
  * @returns {Promise<string>} - The result containing either the approved owner
  *   address or a descriptive error
  */
-export async function getOwnerAndValidateClient(env, clientAddress, rootCid, { logger = console } = {}) {
+export async function getOwnerAndValidateClient(
+  env,
+  clientAddress,
+  rootCid,
+  { logger = console } = {},
+) {
   const query = `
    SELECT ir.set_id, lower(ips.owner) as owner, ipsr.payer, ipsr.with_cdn
    FROM indexer_roots ir
@@ -103,9 +114,9 @@ export async function getOwnerAndValidateClient(env, clientAddress, rootCid, { l
    * }[]}
    */ (
     /** @type {any[]} */ (
-        (await env.DB.prepare(query).bind(rootCid).all()).results
-      )
+      (await env.DB.prepare(query).bind(rootCid).all()).results
     )
+  )
   httpAssert(
     results && results.length > 0,
     404,

--- a/retriever/worker-configuration.d.ts
+++ b/retriever/worker-configuration.d.ts
@@ -10,8 +10,8 @@ declare namespace Cloudflare {
   }
 }
 interface Env extends Cloudflare.Env {
-    PAPERTRAIL_API_TOKEN: string;
-    SERVICE_NAME: any;
+  PAPERTRAIL_API_TOKEN: string
+  SERVICE_NAME: any
 }
 
 // Begin runtime types

--- a/retriever/worker-configuration.d.ts
+++ b/retriever/worker-configuration.d.ts
@@ -9,7 +9,10 @@ declare namespace Cloudflare {
     DB: D1Database
   }
 }
-interface Env extends Cloudflare.Env {}
+interface Env extends Cloudflare.Env {
+    PAPERTRAIL_API_TOKEN: string;
+    SERVICE_NAME: any;
+}
 
 // Begin runtime types
 /*! *****************************************************************************

--- a/retriever/worker-configuration.d.ts
+++ b/retriever/worker-configuration.d.ts
@@ -11,7 +11,7 @@ declare namespace Cloudflare {
 }
 interface Env extends Cloudflare.Env {
   PAPERTRAIL_API_TOKEN: string
-  SERVICE_NAME: any
+  SERVICE_NAME: string
 }
 
 // Begin runtime types

--- a/retriever/wrangler.toml
+++ b/retriever/wrangler.toml
@@ -12,6 +12,7 @@ database_id = "8cc92155-16f6-426a-b782-2965e0daf100"
 ENVIRONMENT = "dev"
 CACHE_TTL = 86400
 DNS_ROOT = ".localhost"
+SERVICE_NAME = "filcdn-retriever"
 
 [[env.dev.d1_databases]]
 binding = "DB"
@@ -22,6 +23,7 @@ database_id = "8cc92155-16f6-426a-b782-2965e0daf101"
 ENVIRONMENT = "calibration "
 CACHE_TTL = 86400
 DNS_ROOT = ".calibration.filcdn.io"
+SERVICE_NAME = "filcdn-retriever"
 
 [[env.calibration .d1_databases]]
 binding = "DB"

--- a/telemetry/papertrail.js
+++ b/telemetry/papertrail.js
@@ -1,0 +1,146 @@
+/**
+ * Papertrail logging utility for sending logs to SolarWinds Papertrail
+ */
+
+class PapertrailLogger {
+    /**
+     * Constructor for PapertrailLogger
+     * @param {Object} options - Configuration options
+     * @param {string} options.apiToken - Papertrail API token
+     * @param {string} options.environment - Environment name (e.g., dev, calibration)
+     * @param {string} options.serviceName - Name of the service for logging
+     * @constructor
+     */
+    constructor(options) {
+        this.apiToken = options.apiToken;
+        this.endpoint = 'https://logs.collector.na-01.cloud.solarwinds.com/v1/logs';
+        this.environment = options.environment;
+        this.serviceName = options.serviceName;
+
+        // Only need to determine if we're in production (calibration environment)
+        this.isProduction = this.environment === 'calibration';
+    }
+
+    /**
+     * Core logging functionality
+     * @param {string} level - Log level (info, warn, error)
+     * @param {string} message - Log message
+     * @param {Object} metadata - Additional metadata
+     * @private
+     */
+    async _logCore(level, message, metadata = {}) {
+        const logData = {
+            time: new Date().toISOString(),
+            level,
+            message,
+            service: this.serviceName,
+            environment: this.environment,
+            ...metadata
+        };
+
+        // If not in production, just use console methods
+        if (!this.isProduction) {
+            // Use appropriate console method based on level
+            if (level === 'error') {
+                console.error(message, metadata);
+            } else if (level === 'warn') {
+                console.warn(message, metadata);
+            } else if(level === 'info') {
+                console.info(message, metadata);
+            }
+            else {
+                console.log(message, metadata);
+            }
+            return;
+        }
+
+        // In production but no API token
+        if (!this.apiToken ) {
+            console.warn('Papertrail API token not configured');
+        }
+
+        try {
+            // Send to Papertrail
+            const response = await fetch(this.endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/octet-stream',
+                    'Authorization': `Bearer ${this.apiToken}`
+                },
+                body: JSON.stringify(logData)
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to send log: ${response.status} ${response.statusText}`);
+            }
+        } catch (error) {
+            // Don't throw errors from the logger itself
+            console.error('Error sending log to Papertrail:', error);
+        }
+    }
+
+    /**
+     * Log a message with specified level
+     * @param {string} message - Log message
+     * @param {Object} metadata - Additional metadata
+     */
+    log(message, metadata = {}) {
+        this._logCore('log', message, metadata);
+    }
+
+    /**
+     * Log an info message
+     * @param {string} message - Log message
+     */
+    info(message, metadata = {}) {
+        this._logCore('info', message, metadata);
+    }
+
+    /**
+     * Log a warning message
+     * @param {string} message - Log message
+     */
+    warn(message, metadata = {}) {
+        this._logCore('warn', message, metadata);
+    }
+
+    /**
+     * Log an error message
+     * @param {unknown} message - Log message
+     */
+    error(message, metadata = {}) {
+        this._logCore('error', typeof message === 'string'?message: JSON.stringify(message), metadata);
+    }
+
+    /**
+     * Create a logger instance from environment variables in Cloudflare Workers
+     * @param {Env} env - Cloudflare Workers environment
+     * @returns {PapertrailLogger} Logger instance
+     */
+    static fromEnv(env) {
+    // The name variable is typically injected by Cloudflare Workers
+    // It comes from the name field in wrangler.toml
+    const serviceName = env.SERVICE_NAME?? 'unknown-service';
+    
+    return new PapertrailLogger({
+            apiToken: env.PAPERTRAIL_API_TOKEN || '',
+            environment: env.ENVIRONMENT || 'dev',
+            serviceName: serviceName
+    });
+    }
+}
+
+/**
+ * Create a logger instance
+ * @param {Env} env - Cloudflare Workers environment
+ * @returns {PapertrailLogger} Logger instance
+ */
+const createLogger = (env ) => {
+    return new PapertrailLogger({
+        apiToken: env.PAPERTRAIL_API_TOKEN,
+        environment: env.ENVIRONMENT,
+        serviceName: env.SERVICE_NAME
+    })
+}
+
+export { createLogger, PapertrailLogger };

--- a/telemetry/papertrail.js
+++ b/telemetry/papertrail.js
@@ -15,7 +15,7 @@ class PapertrailLogger {
     this.environment = environment
     this.serviceName = serviceName
 
-    // Only need to determine if we're in production (calibration environment)
+    // Determine if we are in production
     this.isProduction = this.environment === 'calibration'
   }
 
@@ -81,8 +81,8 @@ class PapertrailLogger {
    * @param {string} message - Log message
    * @param {Object} metadata - Additional metadata
    */
-  log(message, metadata = {}) {
-    this._logCore('log', message, metadata)
+  async log(message, metadata = {}) {
+    await this._logCore('log', message, metadata)
   }
 
   /**
@@ -90,8 +90,8 @@ class PapertrailLogger {
    *
    * @param {string} message - Log message
    */
-  info(message, metadata = {}) {
-    this._logCore('info', message, metadata)
+  async info(message, metadata = {}) {
+    await this._logCore('info', message, metadata)
   }
 
   /**
@@ -99,8 +99,8 @@ class PapertrailLogger {
    *
    * @param {string} message - Log message
    */
-  warn(message, metadata = {}) {
-    this._logCore('warn', message, metadata)
+  async warn(message, metadata = {}) {
+    await this._logCore('warn', message, metadata)
   }
 
   /**
@@ -108,8 +108,8 @@ class PapertrailLogger {
    *
    * @param {unknown} message - Log message
    */
-  error(message, metadata = {}) {
-    this._logCore(
+  async error(message, metadata = {}) {
+    await this._logCore(
       'error',
       typeof message === 'string' ? message : JSON.stringify(message),
       metadata,

--- a/telemetry/papertrail.js
+++ b/telemetry/papertrail.js
@@ -1,146 +1,144 @@
-/**
- * Papertrail logging utility for sending logs to SolarWinds Papertrail
- */
+/** Papertrail logging utility for sending logs to SolarWinds Papertrail */
 
 class PapertrailLogger {
-    /**
-     * Constructor for PapertrailLogger
-     * @param {Object} options - Configuration options
-     * @param {string} options.apiToken - Papertrail API token
-     * @param {string} options.environment - Environment name (e.g., dev, calibration)
-     * @param {string} options.serviceName - Name of the service for logging
-     * @constructor
-     */
-    constructor(options) {
-        this.apiToken = options.apiToken;
-        this.endpoint = 'https://logs.collector.na-01.cloud.solarwinds.com/v1/logs';
-        this.environment = options.environment;
-        this.serviceName = options.serviceName;
+  /**
+   * Constructor for PapertrailLogger
+   *
+   * @class
+   * @param {string} apiToken - Papertrail API token
+   * @param {string} environment - Environment name (e.g., dev, calibration)
+   * @param {string} serviceName - Name of the service for logging
+   */
+  constructor(apiToken, environment, serviceName) {
+    this.apiToken = apiToken
+    this.endpoint = 'https://logs.collector.na-01.cloud.solarwinds.com/v1/logs'
+    this.environment = environment
+    this.serviceName = serviceName
 
-        // Only need to determine if we're in production (calibration environment)
-        this.isProduction = this.environment === 'calibration';
+    // Only need to determine if we're in production (calibration environment)
+    this.isProduction = this.environment === 'calibration'
+  }
+
+  /**
+   * Core logging functionality
+   *
+   * @private
+   * @param {string} level - Log level (info, warn, error)
+   * @param {string} message - Log message
+   * @param {Object} metadata - Additional metadata
+   */
+  async _logCore(level, message, metadata = {}) {
+    const logData = {
+      time: new Date().toISOString(),
+      level,
+      message,
+      service: this.serviceName,
+      environment: this.environment,
+      ...metadata,
     }
 
-    /**
-     * Core logging functionality
-     * @param {string} level - Log level (info, warn, error)
-     * @param {string} message - Log message
-     * @param {Object} metadata - Additional metadata
-     * @private
-     */
-    async _logCore(level, message, metadata = {}) {
-        const logData = {
-            time: new Date().toISOString(),
-            level,
-            message,
-            service: this.serviceName,
-            environment: this.environment,
-            ...metadata
-        };
-
-        // If not in production, just use console methods
-        if (!this.isProduction) {
-            // Use appropriate console method based on level
-            if (level === 'error') {
-                console.error(message, metadata);
-            } else if (level === 'warn') {
-                console.warn(message, metadata);
-            } else if(level === 'info') {
-                console.info(message, metadata);
-            }
-            else {
-                console.log(message, metadata);
-            }
-            return;
-        }
-
-        // In production but no API token
-        if (!this.apiToken ) {
-            console.warn('Papertrail API token not configured');
-        }
-
-        try {
-            // Send to Papertrail
-            const response = await fetch(this.endpoint, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/octet-stream',
-                    'Authorization': `Bearer ${this.apiToken}`
-                },
-                body: JSON.stringify(logData)
-            });
-
-            if (!response.ok) {
-                throw new Error(`Failed to send log: ${response.status} ${response.statusText}`);
-            }
-        } catch (error) {
-            // Don't throw errors from the logger itself
-            console.error('Error sending log to Papertrail:', error);
-        }
+    // If not in production, just use console methods
+    if (!this.isProduction) {
+      // Use appropriate console method based on level
+      if (level === 'error') {
+        console.error(message, metadata)
+      } else if (level === 'warn') {
+        console.warn(message, metadata)
+      } else if (level === 'info') {
+        console.info(message, metadata)
+      } else {
+        console.log(message, metadata)
+      }
+      return
     }
 
-    /**
-     * Log a message with specified level
-     * @param {string} message - Log message
-     * @param {Object} metadata - Additional metadata
-     */
-    log(message, metadata = {}) {
-        this._logCore('log', message, metadata);
-    }
+    try {
+      // Send to Papertrail
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          Authorization: `Bearer ${this.apiToken}`,
+        },
+        body: JSON.stringify(logData),
+      })
 
-    /**
-     * Log an info message
-     * @param {string} message - Log message
-     */
-    info(message, metadata = {}) {
-        this._logCore('info', message, metadata);
+      if (!response.ok) {
+        // We do not throw an error here to avoid breaking the logger
+        console.error(
+          `Failed to send log to Papertrail: ${response.status} ${response.statusText}`,
+        )
+      }
+    } catch (error) {
+      // Don't throw errors from the logger itself
+      console.error('Error sending log to Papertrail:', error)
     }
+  }
 
-    /**
-     * Log a warning message
-     * @param {string} message - Log message
-     */
-    warn(message, metadata = {}) {
-        this._logCore('warn', message, metadata);
-    }
+  /**
+   * Log a message with specified level
+   *
+   * @param {string} message - Log message
+   * @param {Object} metadata - Additional metadata
+   */
+  log(message, metadata = {}) {
+    this._logCore('log', message, metadata)
+  }
 
-    /**
-     * Log an error message
-     * @param {unknown} message - Log message
-     */
-    error(message, metadata = {}) {
-        this._logCore('error', typeof message === 'string'?message: JSON.stringify(message), metadata);
-    }
+  /**
+   * Log an info message
+   *
+   * @param {string} message - Log message
+   */
+  info(message, metadata = {}) {
+    this._logCore('info', message, metadata)
+  }
 
-    /**
-     * Create a logger instance from environment variables in Cloudflare Workers
-     * @param {Env} env - Cloudflare Workers environment
-     * @returns {PapertrailLogger} Logger instance
-     */
-    static fromEnv(env) {
-    // The name variable is typically injected by Cloudflare Workers
-    // It comes from the name field in wrangler.toml
-    const serviceName = env.SERVICE_NAME?? 'unknown-service';
-    
-    return new PapertrailLogger({
-            apiToken: env.PAPERTRAIL_API_TOKEN || '',
-            environment: env.ENVIRONMENT || 'dev',
-            serviceName: serviceName
-    });
-    }
+  /**
+   * Log a warning message
+   *
+   * @param {string} message - Log message
+   */
+  warn(message, metadata = {}) {
+    this._logCore('warn', message, metadata)
+  }
+
+  /**
+   * Log an error message
+   *
+   * @param {unknown} message - Log message
+   */
+  error(message, metadata = {}) {
+    this._logCore(
+      'error',
+      typeof message === 'string' ? message : JSON.stringify(message),
+      metadata,
+    )
+  }
 }
 
 /**
  * Create a logger instance
+ *
  * @param {Env} env - Cloudflare Workers environment
- * @returns {PapertrailLogger} Logger instance
+ * @returns {PapertrailLogger | Console} Logger instance
  */
-const createLogger = (env ) => {
-    return new PapertrailLogger({
-        apiToken: env.PAPERTRAIL_API_TOKEN,
-        environment: env.ENVIRONMENT,
-        serviceName: env.SERVICE_NAME
-    })
+const createLogger = (env) => {
+  if (!env || !env.PAPERTRAIL_API_TOKEN) {
+    console.warn('PAPERTRAIL_API_TOKEN is not set, using console logger')
+    return console
+  }
+  if (!env.ENVIRONMENT) {
+    console.warn('ENVIRONMENT is not set, defaulting to "dev"')
+  }
+  if (!env.SERVICE_NAME) {
+    console.warn('SERVICE_NAME is not set, defaulting to "unknown-service"')
+  }
+  return new PapertrailLogger(
+    env.PAPERTRAIL_API_TOKEN,
+    env.ENVIRONMENT ?? 'dev',
+    env.SERVICE_NAME ?? 'unknown-service',
+  )
 }
 
-export { createLogger, PapertrailLogger };
+export { createLogger, PapertrailLogger }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "retriever",
     "indexer",
     "eslint.config.js",
+    "telemetry",
     "worker-configuration.d.ts"
   ],
   "exclude": ["dist/**/*", "*/test"]


### PR DESCRIPTION
This PR adds logging forwarding to Papertrail (Solarwind) 
The papertrail logger has two modes: 
- Console Mode: Used during testing, and if the API token is not configured 
- Live mode: API token for papertrail is configured, and the environment is production. Forwards logs to papertrail via HTTP. 

The logger sends a JSON object with all the relevant information about the log to papertrail. From there, the logs can be filtered for log levels, service names,... 
Papertrail auto detects logs from a new source and based on the API key the logs from the filCDN worker are grouped under [FilCDN](https://my.na-01.cloud.solarwinds.com/226597991117913088/groups/g-1000000000000008591?duration=3600). This makes the logs organized and easy to look up. 
In a subsequent step, an alert from papertrail will be set up to be forwarded to the slack alerts channel. 

Functions that use logging have a logger as an optional parameter. If no logger is passed, then it defaults back to the console logger. 

The log function is async, to make sure that the sending of logs to papertrail does not cause service degradation, the log calls are not awaited for. This ensures that the async log calls are run in the background and do not block the ongoing retriever worker from processing requests fast. 

Related to: 
https://github.com/filcdn/roadmap/issues/23