### PR TITLE
Refactor: compare in sql

### DIFF
--- a/bad-bits/bin/scheduler.js
+++ b/bad-bits/bin/scheduler.js
@@ -4,10 +4,8 @@ export default {
   async scheduled(_controller, env, _ctx) {
     console.log('Running scheduled badbits update...')
     try {
-      const result = await fetchAndStoreBadBits(env)
-      console.log(
-        `Updated badbits denylist: ${result.added} added, ${result.removed} removed`,
-      )
+      await fetchAndStoreBadBits(env)
+      console.log('Updated badbits denylist')
     } catch (error) {
       console.error('Failed to update badbits denylist:', error)
     }

--- a/bad-bits/lib/badbits.js
+++ b/bad-bits/lib/badbits.js
@@ -32,6 +32,5 @@ export async function fetchAndStoreBadBits(
       }
     }
   }
-  const updateResult = await updateBadBitsDatabase(env, currentBadHashes)
-  return updateResult
+  await updateBadBitsDatabase(env, currentBadHashes)
 }

--- a/bad-bits/lib/store.js
+++ b/bad-bits/lib/store.js
@@ -4,60 +4,29 @@
  * @param {Object} env - Environment containing database connection
  * @param {Set<string>} currentHashes - Set of current valid hashes from
  *   denylist
- * @returns {Promise<{ added: number; removed: number }>} - Number of entries
- *   added and removed
  */
 export async function updateBadBitsDatabase(env, currentHashes) {
   try {
-    // Get existing hashes
-    const existingHashes = new Set(await getAllBadBitHashes(env))
-
-    // Determine hashes to add and remove
-    const hashesToAdd = [...currentHashes].filter(
-      (hash) => !existingHashes.has(hash),
+    const now = new Date()
+    await env.DB.batch(
+      [
+        currentHashes.map((hash) =>
+          env.DB.prepare(
+            `
+          INSERT INTO badbits (hash) VALUES (?)
+          ON CONFLICT(hash) DO UPDATE SET last_modified_at = ?
+        `,
+          ).bind(hash, now.toISOString()),
+        ),
+        env.DB.prepare(
+          `
+        DELETE FROM badbits WHERE last_modified_at < ?
+      `,
+        ).bind(now.toISOString()),
+      ].flatMap(),
     )
-    const hashesToRemove = [...existingHashes].filter(
-      (hash) => !currentHashes.has(hash),
-    )
-
-    // Prepare database operations
-    const dbOperations = []
-    // Add new hashes
-    if (hashesToAdd.length > 0) {
-      const insertStmt = env.DB.prepare('INSERT INTO badbits (hash) VALUES (?)')
-      hashesToAdd.forEach((hash) => {
-        dbOperations.push(insertStmt.bind(hash))
-      })
-    }
-
-    // Remove old hashes
-    if (hashesToRemove.length > 0) {
-      const deleteStmt = env.DB.prepare('DELETE FROM badbits WHERE hash = ?')
-      hashesToRemove.forEach((hash) => {
-        dbOperations.push(deleteStmt.bind(hash))
-      })
-    }
-    // Execute all operations in a single atomic batch if there are any operations
-    if (dbOperations.length > 0) {
-      await env.DB.batch(dbOperations)
-    }
-    return {
-      added: hashesToAdd.length,
-      removed: hashesToRemove.length,
-    }
   } catch (error) {
     console.error('Error updating badbits database:', error)
     throw error
   }
-}
-
-/**
- * Gets all bad bit hashes from the database
- *
- * @param {Object} env - Environment containing database connection
- * @returns {Promise<string[]>} - Array of hash strings
- */
-export async function getAllBadBitHashes(env) {
-  const { results } = await env.DB.prepare('SELECT hash FROM badbits').all()
-  return results.map((entry) => entry.hash)
 }

--- a/bad-bits/lib/store.js
+++ b/bad-bits/lib/store.js
@@ -10,20 +10,20 @@ export async function updateBadBitsDatabase(env, currentHashes) {
     const now = new Date()
     await env.DB.batch(
       [
-        currentHashes.map((hash) =>
+        Array.from(currentHashes).map((hash) =>
           env.DB.prepare(
             `
-          INSERT INTO badbits (hash) VALUES (?)
+          INSERT INTO badbits (hash, last_modified_at) VALUES (?, ?)
           ON CONFLICT(hash) DO UPDATE SET last_modified_at = ?
         `,
-          ).bind(hash, now.toISOString()),
+          ).bind(hash, now.toISOString(), now.toISOString()),
         ),
         env.DB.prepare(
           `
         DELETE FROM badbits WHERE last_modified_at < ?
       `,
         ).bind(now.toISOString()),
-      ].flatMap(),
+      ].flat(),
     )
   } catch (error) {
     console.error('Error updating badbits database:', error)

--- a/bad-bits/test/badbits.test.js
+++ b/bad-bits/test/badbits.test.js
@@ -35,7 +35,9 @@ describe('fetchAndStoreBadBits', () => {
     const initialHashes = ['hash1', 'hash2', 'hash3']
     await env.DB.batch(
       initialHashes.map((hash) =>
-        env.DB.prepare('INSERT INTO badbits (hash) VALUES (?)').bind(hash),
+        env.DB.prepare(
+          'INSERT INTO badbits (hash, last_modified_at) VALUES (?, ?)',
+        ).bind(hash, new Date().toISOString()),
       ),
     )
 

--- a/bad-bits/test/store.test.js
+++ b/bad-bits/test/store.test.js
@@ -22,9 +22,12 @@ describe('updateBadBitsDatabase', () => {
   it('removes hashes not in the current set', async () => {
     // Insert some initial hashes into the database
     const initialHashes = ['hash1', 'hash2', 'hash3']
+    const now = '2020-01-01T00:00:00.000Z'
     await env.DB.batch(
       initialHashes.map((hash) =>
-        env.DB.prepare('INSERT INTO badbits (hash) VALUES (?)').bind(hash),
+        env.DB.prepare(
+          'INSERT INTO badbits (hash, last_modified_at) VALUES (?, ?)',
+        ).bind(hash, now),
       ),
     )
 
@@ -43,11 +46,14 @@ describe('updateBadBitsDatabase', () => {
 
   it('does not modify the database if hashes are unchanged', async () => {
     const currentHashes = new Set(['hash1', 'hash2', 'hash3'])
+    const now = '2020-01-01T00:00:00.000Z'
 
     // Insert the same hashes into the database
     await env.DB.batch(
       [...currentHashes].map((hash) =>
-        env.DB.prepare('INSERT INTO badbits (hash) VALUES (?)').bind(hash),
+        env.DB.prepare(
+          'INSERT INTO badbits (hash, last_modified_at) VALUES (?, ?)',
+        ).bind(hash, now),
       ),
     )
 

--- a/bad-bits/test/store.test.js
+++ b/bad-bits/test/store.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeAll, expect } from 'vitest'
-import { updateBadBitsDatabase, getAllBadBitHashes } from '../lib/store.js'
+import { updateBadBitsDatabase } from '../lib/store.js'
 import { env } from 'cloudflare:test'
+import { getAllBadBitHashes } from './util.js'
 
 describe('updateBadBitsDatabase', () => {
   beforeAll(async () => {
@@ -11,13 +12,11 @@ describe('updateBadBitsDatabase', () => {
   it('adds new hashes to the database', async () => {
     const currentHashes = new Set(['hash1', 'hash2', 'hash3'])
 
-    const result = await updateBadBitsDatabase(env, currentHashes)
+    await updateBadBitsDatabase(env, currentHashes)
     const storedHashes = new Set(await getAllBadBitHashes(env))
 
     // Verify the database contains the new hashes
     expect(storedHashes).toEqual(currentHashes)
-    expect(result.added).toBe(currentHashes.size)
-    expect(result.removed).toBe(0)
   })
 
   it('removes hashes not in the current set', async () => {
@@ -31,13 +30,11 @@ describe('updateBadBitsDatabase', () => {
 
     const currentHashes = new Set(['hash2', 'hash4'])
 
-    const result = await updateBadBitsDatabase(env, currentHashes)
+    await updateBadBitsDatabase(env, currentHashes)
     const storedHashes = new Set(await getAllBadBitHashes(env))
 
     // Verify the database contains only the current hashes
     expect(storedHashes).toEqual(currentHashes)
-    expect(result.added).toBe(1) // 'hash4' added
-    expect(result.removed).toBe(2) // 'hash1' and 'hash3' removed
     expect(storedHashes.has('hash1')).toBe(false)
     expect(storedHashes.has('hash3')).toBe(false)
     expect(storedHashes.has('hash2')).toBe(true)
@@ -54,12 +51,10 @@ describe('updateBadBitsDatabase', () => {
       ),
     )
 
-    const result = await updateBadBitsDatabase(env, currentHashes)
+    await updateBadBitsDatabase(env, currentHashes)
     const storedHashes = new Set(await getAllBadBitHashes(env))
 
     // Verify the database remains unchanged
     expect(storedHashes).toEqual(currentHashes)
-    expect(result.added).toBe(0)
-    expect(result.removed).toBe(0)
   })
 })

--- a/bad-bits/test/util.js
+++ b/bad-bits/test/util.js
@@ -1,0 +1,10 @@
+/**
+ * Gets all bad bit hashes from the database
+ *
+ * @param {Object} env - Environment containing database connection
+ * @returns {Promise<string[]>} - Array of hash strings
+ */
+export async function getAllBadBitHashes(env) {
+  const { results } = await env.DB.prepare('SELECT hash FROM badbits').all()
+  return results.map((entry) => entry.hash)
+}

--- a/db/migrations/0009_add_badbits_table.sql
+++ b/db/migrations/0009_add_badbits_table.sql
@@ -1,4 +1,7 @@
 -- Create table for storing bad bits
 CREATE TABLE IF NOT EXISTS badbits (
-  hash TEXT PRIMARY KEY
+  hash TEXT PRIMARY KEY,
+  last_modified_at TIMESTAMP NOT NULL
 );
+
+CREATE INDEX IF NOT EXISTS idx_badbits_last_modified_at ON badbits(last_modified_at);


### PR DESCRIPTION
Move the badbits comparison to sql, speeding up and simplifying code. As a downside, the update stats have been removed. I doubt these are high value rn.