### PR TITLE
ci: run against any commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
For example, CI isn't running on https://github.com/filcdn/worker/pull/145, since it isn't targeting `main`