### PR TITLE
feat: redirect `/` to `https://filcdn.com/`

### DIFF
--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -50,10 +50,14 @@ export default {
     ctx,
     { retrieveFile = defaultRetrieveFile, signal } = {},
   ) {
+    httpAssert(request.method === 'GET', 405, 'Method Not Allowed')
+    if (URL.parse(request.url)?.pathname === '/') {
+      return Response.redirect('https://filcdn.com/', 302)
+    }
+
     const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
     const requestCountryCode = request.headers.get('CF-IPCountry')
-    httpAssert(request.method === 'GET', 405, 'Method Not Allowed')
 
     const { clientWalletAddress, rootCid } = parseRequest(request, env)
 

--- a/retriever/test/retriever.test.js
+++ b/retriever/test/retriever.test.js
@@ -70,6 +70,20 @@ describe('retriever.fetch', () => {
     }
   })
 
+  it('redirects to https://filcdn.com when no CID was provided', async () => {
+    const req = new Request(`https://${defaultClientAddress}${DNS_ROOT}/`)
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toBe('https://filcdn.com/')
+  })
+
+  it('redirects to https://filcdn.com when no CID and no wallet address were provided', async () => {
+    const req = new Request(`https://${DNS_ROOT.slice(1)}/`)
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toBe('https://filcdn.com/')
+  })
+
   it('returns 405 for non-GET requests', async () => {
     const req = withRequest(1, 'foo', 'POST')
     const res = await worker.fetch(req, env)
@@ -487,7 +501,7 @@ function withRequest(
 ) {
   let url = 'http://'
   if (clientWalletAddress) url += `${clientWalletAddress}.`
-  url += DNS_ROOT.slice(1) // remove the trailing '.'
+  url += DNS_ROOT.slice(1) // remove the leading '.'
   if (rootCid) url += `/${rootCid}`
 
   return new Request(url, { method, headers })


### PR DESCRIPTION
User story:

As a copyright owner, I discovered that a copy of my protected artwork can be freely downloaded via `https://{wallet}. filcdn.io/{cid}`. I would like to submit a takedown request. The first thing that comes to my mind is to open https://filcdn.io/ to learn more about this service. Thankfully, I am redirected to https://filcdn.com/, where I find the contact information I was looking for.

Close #30
