### PR TITLE
Remove reviewers from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
     commit-message:
       prefix: 'deps'
       prefix-development: 'deps(dev)'
-    reviewers:
-      - 'bajtos'
-      - 'juliangruber'
-      - 'pyropy'
-      - 'NikolasHaimerl'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
@@ -24,8 +19,3 @@ updates:
       timezone: 'Europe/Berlin'
     commit-message:
       prefix: 'ci'
-    reviewers:
-      - 'bajtos'
-      - 'juliangruber'
-      - 'pyropy'
-      - 'NikolasHaimerl'


### PR DESCRIPTION
See https://github.com/filcdn/worker/pull/150#issuecomment-3051582563

> The `reviewers` field in the `dependabot.yml` file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

