### PR TITLE
feat: content-security-policy to prevent phishing

### DIFF
--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -84,7 +84,7 @@ export default {
     const spURL =
       OWNER_TO_RETRIEVAL_URL_MAPPING[ownerAddress]?.url ||
       (await getProviderUrl(ownerAddress, env))
-    const { response, cacheMiss } = await retrieveFile(
+    const { response: originResponse, cacheMiss } = await retrieveFile(
       spURL,
       rootCid,
       env.CACHE_TTL,
@@ -96,7 +96,7 @@ export default {
       clientAddress: clientWalletAddress,
       cacheMiss,
       egressBytes: null, // Will be populated later
-      responseStatus: response.status,
+      responseStatus: originResponse.status,
       timestamp: requestTimestamp,
       performanceStats: {
         fetchTtfb: null, // Will be populated later
@@ -106,7 +106,7 @@ export default {
       requestCountryCode,
     }
 
-    if (!response.body) {
+    if (!originResponse.body) {
       // The upstream response does not have any readable body
       // There is no need to measure response body size, we can
       // return the original response object.
@@ -122,14 +122,14 @@ export default {
           },
         }),
       )
-      const clonedResponse = new Response(response.body, response)
-      setContentSecurityPolicy(clonedResponse)
-      return clonedResponse
+      const response = new Response(originResponse.body, originResponse)
+      setContentSecurityPolicy(response)
+      return response
     }
 
     // Stream and count bytes
     // We create two identical streams, one for the egress measurement and the other for returning the response as soon as possible
-    const [returnedStream, egressMeasurementStream] = response.body.tee()
+    const [returnedStream, egressMeasurementStream] = originResponse.body.tee()
     const reader = egressMeasurementStream.getReader()
     const firstByteAt = performance.now()
 
@@ -151,13 +151,13 @@ export default {
     )
 
     // Return immediately, proxying the transformed response
-    const clonedResponse = new Response(returnedStream, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
+    const response = new Response(returnedStream, {
+      status: originResponse.status,
+      statusText: originResponse.statusText,
+      headers: originResponse.headers,
     })
-    setContentSecurityPolicy(clonedResponse)
-    return clonedResponse
+    setContentSecurityPolicy(response)
+    return response
   },
 
   /**

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -11,6 +11,7 @@ import {
   logRetrievalResult,
 } from '../lib/store.js'
 import { httpAssert } from '../lib/http-assert.js'
+import { setContentSecurityPolicy } from '../lib/content-security-policy.js'
 
 export default {
   /**
@@ -121,7 +122,9 @@ export default {
           },
         }),
       )
-      return response
+      const clonedResponse = new Response(response.body, response)
+      setContentSecurityPolicy(clonedResponse)
+      return clonedResponse
     }
 
     // Stream and count bytes
@@ -148,11 +151,13 @@ export default {
     )
 
     // Return immediately, proxying the transformed response
-    return new Response(returnedStream, {
+    const clonedResponse = new Response(returnedStream, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
     })
+    setContentSecurityPolicy(clonedResponse)
+    return clonedResponse
   },
 
   /**

--- a/retriever/lib/content-security-policy.js
+++ b/retriever/lib/content-security-policy.js
@@ -11,8 +11,9 @@ const ALLOWED_HOSTS = [
 ]
 
 /**
- * @param {Response} response This response must be a writeable Response object
- *   (i.e. you must clone the Reponse object returned by `fetch`.)
+ * @param {Response} response A Response object we can modify (i.e. you must
+ *   clone the Reponse object returned by `fetch` before passing it to this
+ *   function).
  */
 export function setContentSecurityPolicy(response) {
   // This functions sets the Content Security Policy (CSP) header for the response.

--- a/retriever/lib/content-security-policy.js
+++ b/retriever/lib/content-security-policy.js
@@ -1,0 +1,45 @@
+// List of allowed hosts in the CSP <host-source> format:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#host-source
+const ALLOWED_HOSTS = [
+  'https://*.filcdn.io',
+  'https://*.calibration.filcdn.io',
+
+  // Other service serving content-addressable or static assets
+  'https://*.w3s.link',
+  'https://*.dweb.link',
+  'https://*.githubusercontent.com',
+]
+
+/**
+ * @param {Response} response This response must be a writeable Response object
+ *   (i.e. you must clone the Reponse object returned by `fetch`.)
+ */
+export function setContentSecurityPolicy(response) {
+  // This functions sets the Content Security Policy (CSP) header for the response.
+  // CSP is a security feature that helps prevent attacks like Cross-Site Scripting (XSS) by specifying which sources of content are allowed to be loaded by the browser.
+  // Learn more:
+  //   https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  //   https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
+  //
+  // Our implementation is inspired by w3s.link:
+  // https://github.com/storacha/w3link/blob/d73e3783c4c520e85e96dba1a2eb507da0f3cbb3/packages/edge-gateway-link/src/gateway.js#L74-L98
+
+  const allowedHostsAsString = ALLOWED_HOSTS.join(' ')
+
+  // The `default-src` directive controls the default sources for most content types.
+  // - `'self'` allows content from the same origin.
+  // - `'unsafe-inline'` and `'unsafe-eval'` allow inline scripts and eval (not recommended for strong security, but sometimes needed for legacy code).
+  // - `blob:` and `data:` allow loading resources from blob and data URLs.
+  // - `${allowedHostsAsString}` allows content from the specified external hosts.
+  // Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
+  const defaultSrc = `'self' 'unsafe-inline' 'unsafe-eval' blob: data: ${allowedHostsAsString}`
+
+  // Set the CSP header with various directives:
+  // - `default-src`: as described above.
+  // - `form-action 'self'`: restricts where forms can be submitted. Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action
+  // - `navigate-to 'self'`: restricts which URLs the document can navigate to. Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to
+  response.headers.set(
+    'content-security-policy',
+    `default-src: ${defaultSrc}; form-action 'self'; navigate-to 'self';`,
+  )
+}

--- a/retriever/lib/content-security-policy.js
+++ b/retriever/lib/content-security-policy.js
@@ -2,7 +2,6 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#host-source
 const ALLOWED_HOSTS = [
   'https://*.filcdn.io',
-  'https://*.calibration.filcdn.io',
 
   // Other service serving content-addressable or static assets
   'https://*.w3s.link',

--- a/retriever/test/retriever.test.js
+++ b/retriever/test/retriever.test.js
@@ -113,6 +113,23 @@ describe('retriever.fetch', () => {
     expect(res.headers.get('X-Test')).toBe('yes')
   })
 
+  it('sets Content-Security-Policy response header', async () => {
+    const originResponse = new Response('hello', {
+      headers: {
+        'Content-Security-Policy': 'report-uri: https://endpoint.example.com',
+      },
+    })
+    const mockRetrieveFile = vi.fn().mockResolvedValue({
+      response: originResponse,
+      cacheMiss: true,
+    })
+    const req = withRequest(defaultClientAddress, realRootCid)
+    const res = await worker.fetch(req, env, { retrieveFile: mockRetrieveFile })
+    const csp = res.headers.get('Content-Security-Policy')
+    expect(csp).toMatch(/^default-src: 'self'/)
+    expect(csp).toContain('https://*.filcdn.io')
+  })
+
   it('fetches the file from calibration storage provider', async () => {
     const expectedHash =
       '358f5611998981d5c5584ca2457f5b87afdf7b69650e1919f6e28f0f76943491'


### PR DESCRIPTION
Enable Content Security Policy (CSP) in CDN responses to prevent malicious users from using our CDN for phishing. 

CSP is a security feature that helps prevent attacks like Cross-Site Scripting (XSS) by specifying which sources of content are allowed to be loaded by the browser.

The goal of this pull request is to configure the CDN response in such a way that browsers will not allow the page to interact with other services & websites.

In a nutshell:
- Allow self, inline, eval, blob, data and white-listed hosts as a source for JS, CSS, images, etc.
- Disable navigation or form submissions to other pages

List of allowed hosts - I expect us to evolve this list over time based on user feedback.
```js
const ALLOWED_HOSTS = [
  'https://*.filcdn.io',
  'https://*.calibration.filcdn.io',

  // Other services serving content-addressable or static assets
  'https://*.w3s.link',
  'https://*.dweb.link',
  'https://*.githubusercontent.com',
]
```

I decided to leave out reporting of CSP violations from this pull request and created a follow-up issue here:
- https://github.com/filcdn/worker/issues/156

Links:
- https://github.com/filcdn/roadmap/issues/31
- https://github.com/storacha/w3link/blob/d73e3783c4c520e85e96dba1a2eb507da0f3cbb3/packages/edge-gateway-link/src/gateway.js#L74-L98

