### PR TITLE
fix: avoid double slash in piece retrieval URLs

### DIFF
--- a/retriever/lib/retrieval.js
+++ b/retriever/lib/retrieval.js
@@ -21,7 +21,7 @@ export async function retrieveFile(
   cacheTtl = 86400,
   { signal } = {},
 ) {
-  const url = `${baseUrl}/piece/${pieceCid}`
+  const url = getRetrievalUrl(baseUrl, pieceCid)
   const response = await fetch(url, {
     cf: {
       cacheTtlByStatus: {
@@ -60,4 +60,16 @@ export async function measureStreamedEgress(reader) {
     total += value.length
   }
   return total
+}
+
+/**
+ * @param {string} pieceRetrievalBaseUrl
+ * @param {string} pieceCid
+ * @returns {string}
+ */
+export function getRetrievalUrl(pieceRetrievalBaseUrl, pieceCid) {
+  if (!pieceRetrievalBaseUrl.endsWith('/')) {
+    pieceRetrievalBaseUrl += '/'
+  }
+  return `${pieceRetrievalBaseUrl}piece/${pieceCid}`
 }

--- a/retriever/test/retrieval.test.js
+++ b/retriever/test/retrieval.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { retrieveFile } from '../lib/retrieval.js'
+import { retrieveFile, getRetrievalUrl } from '../lib/retrieval.js'
 
 describe('retrieveFile', () => {
   const baseUrl = 'https://example.com'
@@ -52,5 +52,17 @@ describe('retrieveFile', () => {
     fetchMock.mockResolvedValueOnce(response)
     const result = await retrieveFile(baseUrl, rootCid)
     expect(result.response).toBe(response)
+  })
+})
+
+describe('getRetrievalUrl', () => {
+  it('appends the endpoint name and piece CID to the base URL', () => {
+    const url = getRetrievalUrl('https://example.com', 'bafy123abc')
+    expect(url).toBe('https://example.com/piece/bafy123abc')
+  })
+
+  it('avoids double slash in path when the base URL ends with a slash', () => {
+    const url = getRetrievalUrl('https://example.com/', 'bafy123abc')
+    expect(url).toBe('https://example.com/piece/bafy123abc')
   })
 })


### PR DESCRIPTION
Before this change, when the provider's URL ended with `/`, we constructed an URL with double slash in the path, e.g.

    https://polynomial.computer//piece/baga123

Curio does not support such paths and returns 404.

In this patch, I fix the code building the URL to handle this edge case and construct a correct URL with a single slash, e.g.

    https://polynomial.computer/piece/baga123

Links:
- https://github.com/filcdn/roadmap/issues/13
