### PR TITLE
Add naive HEAD request support

### DIFF
--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -46,7 +46,11 @@ export default {
     ctx,
     { retrieveFile = defaultRetrieveFile, signal } = {},
   ) {
-    httpAssert(request.method === 'GET', 405, 'Method Not Allowed')
+    httpAssert(
+      ['GET', 'HEAD'].includes(request.method),
+      405,
+      'Method Not Allowed',
+    )
     if (URL.parse(request.url)?.pathname === '/') {
       return Response.redirect('https://filcdn.com/', 302)
     }

--- a/retriever/test/retriever.test.js
+++ b/retriever/test/retriever.test.js
@@ -91,7 +91,7 @@ describe('retriever.fetch', () => {
     expect(res.headers.get('Location')).toBe('https://filcdn.com/')
   })
 
-  it('returns 405 for non-GET requests', async () => {
+  it('returns 405 for unsupported request methods', async () => {
     const req = withRequest(1, 'foo', 'POST')
     const res = await worker.fetch(req, env)
     expect(res.status).toBe(405)
@@ -444,6 +444,19 @@ describe('retriever.fetch', () => {
     expect(await res.text()).toBe(
       `No approved storage provider found for client '0x2a06d234246ed18b6c91de8349ff34c22c7268e8' and root_cid 'bagaTest'.`,
     )
+  })
+
+  it('supports HEAD requests', async () => {
+    const fakeResponse = new Response('file content', {
+      status: 200,
+    })
+    const mockRetrieveFile = vi.fn().mockResolvedValue({
+      response: fakeResponse,
+      cacheMiss: true,
+    })
+    const req = withRequest(defaultClientAddress, realRootCid, 'HEAD')
+    const res = await worker.fetch(req, env, { retrieveFile: mockRetrieveFile })
+    expect(res.status).toBe(200)
   })
 })
 


### PR DESCRIPTION
Trying to use https://speedvitals.com/ttfb-test, I noticed that the CDN doesn't support HEAD requests yet.

To start off with a very simple and problem-free implementation (that even includes the reponse body, which is not against the spec), simply treat HEAD requests like GET requests.

I'm going to merge this before review, to unblock TTFB monitoring. Please hindsight review 🙏 