### PR TITLE
feat: Check if payer address is sanctioned during indexing

### DIFF
--- a/db/migrations/0008_add_payer_sanctioned_column.sql
+++ b/db/migrations/0008_add_payer_sanctioned_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE indexer_proof_set_rails ADD COLUMN is_payer_sanctioned BOOLEAN;

--- a/indexer/bin/indexer.js
+++ b/indexer/bin/indexer.js
@@ -164,10 +164,13 @@ export default {
       console.log(
         `New proof set rail (proof_set_id=${payload.proof_set_id}, rail_id=${payload.rail_id}, payer=${payload.payer}, payee=${payload.payee}, with_cdn=${payload.with_cdn})`,
       )
-      const isPayerSanctioned = await isAddressSanctioned(
-        CHAINALYSIS_API_KEY,
-        payload.payer,
-      )
+      let isPayerSanctioned
+      if (payload.with_cdn) {
+        isPayerSanctioned = await isAddressSanctioned(
+          CHAINALYSIS_API_KEY,
+          payload.payer,
+        )
+      }
       await env.DB.prepare(
         `
           INSERT INTO indexer_proof_set_rails (
@@ -188,7 +191,7 @@ export default {
           payload.payer,
           payload.payee,
           payload.with_cdn ?? null,
-          isPayerSanctioned,
+          isPayerSanctioned ?? null,
         )
         .run()
       return new Response('OK', { status: 200 })

--- a/indexer/lib/chainalysis.js
+++ b/indexer/lib/chainalysis.js
@@ -1,0 +1,43 @@
+/**
+ * Check a single address with the Chainalysis API
+ *
+ * @param {string} apiKey - Chainalysis API key
+ * @param {string} address - Ethereum address to check
+ * @param {Object} options - Additional options
+ * @param {Function} [options.fetch] - Custom fetch function for testing
+ * @returns {Promise<boolean | null>}
+ */
+export async function isAddressSanctioned(
+  apiKey,
+  address,
+  { fetch = globalThis.fetch } = {},
+) {
+  try {
+    const url = `https://public.chainalysis.com/api/v1/address/${address}`
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-API-KEY': apiKey,
+        Accept: 'application/json',
+      },
+    })
+
+    if (!response.ok) {
+      console.error(
+        `Chainalysis API error: ${response.status} ${response.statusText}`,
+      )
+
+      return null
+    }
+
+    const data = await response.json()
+
+    // If identifications array exists and is not empty, there exists a sanction for this address
+    // We do not look into which sanctions are applied, just whether any exist
+    return data.identifications && data.identifications.length > 0
+  } catch (error) {
+    console.error('Error checking address:', error)
+    return null
+  }
+}

--- a/indexer/test/chainalysis.test.js
+++ b/indexer/test/chainalysis.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isAddressSanctioned } from '../lib/chainalysis.js'
+
+describe('isAddressSanctioned', () => {
+  const apiKey = 'test-api-key'
+  let mockFetch
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.resetAllMocks()
+
+    // Setup fetch mock
+    mockFetch = vi.fn()
+  })
+
+  it('makes correct API call', async () => {
+    // Setup
+    const address = '0x1111111111111111111111111111111111111111'
+
+    // Mock successful responses
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ identifications: [] }),
+    })
+
+    // Execute
+    const result = await isAddressSanctioned(apiKey, address, {
+      fetch: mockFetch,
+    })
+
+    // Verify
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://public.chainalysis.com/api/v1/address/0x1111111111111111111111111111111111111111',
+      {
+        method: 'GET',
+        headers: {
+          'X-API-KEY': apiKey,
+          Accept: 'application/json',
+        },
+      },
+    )
+    expect(result).toEqual(false) // Assuming the address is not sanctioned
+  })
+
+  it('correctly identifies sanctioned addresses', async () => {
+    const sanctionedAddress = '0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC'
+
+    // Mock response for sanctioned address
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          identifications: [
+            {
+              category: 'sanctions',
+              name: 'SANCTIONS: Test Sanctioned Entity',
+            },
+          ],
+        }),
+    })
+
+    // Execute
+    const result = await isAddressSanctioned(apiKey, sanctionedAddress, {
+      fetch: mockFetch,
+    })
+
+    // Verify
+    expect(result).toEqual(true)
+  })
+
+  it('returns null on API errors', async () => {
+    const address = '0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC'
+
+    // Mock error response
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+    })
+
+    // Execute
+    const result = await isAddressSanctioned(apiKey, address, {
+      fetch: mockFetch,
+    })
+
+    // Verify
+    expect(result).toBeNull()
+  })
+
+  it('returns null on exception', async () => {
+    const address = ['0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC']
+
+    // Mock fetch throwing an exception
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    // Execute
+    const result = await isAddressSanctioned(address, apiKey, {
+      fetch: mockFetch,
+    })
+
+    // Verify
+    expect(result).toBeNull()
+  })
+})

--- a/indexer/test/indexer.test.js
+++ b/indexer/test/indexer.test.js
@@ -434,6 +434,7 @@ describe('retriever.indexer', () => {
         .all()
       expect(proofSetRails.length).toBe(1)
       expect(proofSetRails[0].with_cdn).toBeNull()
+      expect(proofSetRails[0].is_payer_sanctioned).toBeNull()
     })
 
     it('stores numeric ID values as integers', async () => {
@@ -467,7 +468,7 @@ describe('retriever.indexer', () => {
       expect(proofSetRails[0]?.rail_id).toMatch(/^\d+$/)
     })
 
-    it('checks if payer address is sanctioned', async () => {
+    it('checks if payer address is sanctioned when with_cdn = true', async () => {
       const proofSetId = randomId()
       const railId = randomId()
       const req = new Request('https://host/proof-set-rail-created', {


### PR DESCRIPTION
This PR builds on the approach introduced in #143 by adding a check to determine if the payer address is sanctioned during the indexing of the proof-set rail creation.

While the checks from #143 run every 24 hours, they leave a window during which sanctioned addresses might perform retrievals before being flagged. This PR addresses that gap by introducing an check at indexing time, triggered only when the `with_cdn` flag is enabled for the proof-set rail.


Related to:
- https://github.com/filcdn/roadmap/issues/17
- #143 
