### PR TITLE
feat: batch bad-bits SQL updates by 1000 items

### DIFF
--- a/bad-bits/lib/bad-bits.js
+++ b/bad-bits/lib/bad-bits.js
@@ -49,5 +49,11 @@ export async function fetchAndStoreBadBits(
       }
     }
   }
-  await updateBadBitsDatabase(env, currentBadHashes, etag)
+
+  try {
+    await updateBadBitsDatabase(env, currentBadHashes, etag)
+  } catch (error) {
+    console.error('Error updating bad bits:', error)
+    throw error
+  }
 }

--- a/bad-bits/lib/store.js
+++ b/bad-bits/lib/store.js
@@ -7,6 +7,7 @@
  * @param {string} etag - ETag for the current denylist
  */
 export async function updateBadBitsDatabase(env, currentHashes, etag) {
+  const startedAt = Date.now()
   const now = new Date().toISOString()
   const insertBadBitStmt = env.DB.prepare(
     `
@@ -15,26 +16,29 @@ export async function updateBadBitsDatabase(env, currentHashes, etag) {
       `,
   )
 
+  let updated = 0
   const remainingHashes = Array.from(currentHashes)
   while (remainingHashes.length > 0) {
     // pop first 1000 hashes from remainingHashes
     const batchHashes = remainingHashes.splice(0, 1000)
+    updated += batchHashes.length
     await env.DB.batch(
       batchHashes.map((hash) => insertBadBitStmt.bind(hash, now)),
+    )
+    console.log(
+      `Inserted/updated ${updated} bad bits in ${Date.now() - startedAt}ms`,
     )
   }
 
   const statements = [
-    env.DB.prepare('DELETE FROM bad_bits WHERE last_modified_at < ?').bind(
-      now.toISOString(),
-    ),
+    env.DB.prepare('DELETE FROM bad_bits WHERE last_modified_at < ?').bind(now),
   ]
 
   if (etag) {
     statements.push(
       env.DB.prepare(
         'INSERT INTO bad_bits_history (timestamp, etag) VALUES (?, ?)',
-      ).bind(now.toISOString(), etag),
+      ).bind(now, etag),
     )
   }
 

--- a/bad-bits/wrangler.toml
+++ b/bad-bits/wrangler.toml
@@ -28,4 +28,4 @@ database_name = "filcdn-db"
 database_id = "8cc92155-16f6-426a-b782-2965e0daf103"
 
 [env.calibration.triggers]
-crons = ["*/5 * * * *"]  # Run every 5 minutes
+crons = ["* * * * *"]  # Run every 1 minute


### PR DESCRIPTION
The bad-bits updater worker fails with Exceeded Resources.

In this pull request, I am reworking the code executing SQL update queries to execute updates in batches of 1000 items.
