### PR TITLE
fix: typo in Content-Security-Policy

### DIFF
--- a/retriever/lib/content-security-policy.js
+++ b/retriever/lib/content-security-policy.js
@@ -40,6 +40,6 @@ export function setContentSecurityPolicy(response) {
   // - `navigate-to 'self'`: restricts which URLs the document can navigate to. Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to
   response.headers.set(
     'content-security-policy',
-    `default-src: ${defaultSrc}; form-action 'self'; navigate-to 'self';`,
+    `default-src ${defaultSrc}; form-action 'self'; navigate-to 'self';`,
   )
 }

--- a/retriever/test/retriever.test.js
+++ b/retriever/test/retriever.test.js
@@ -147,7 +147,7 @@ describe('retriever.fetch', () => {
     const req = withRequest(defaultClientAddress, realRootCid)
     const res = await worker.fetch(req, env, { retrieveFile: mockRetrieveFile })
     const csp = res.headers.get('Content-Security-Policy')
-    expect(csp).toMatch(/^default-src: 'self'/)
+    expect(csp).toMatch(/^default-src 'self'/)
     expect(csp).toContain('https://*.filcdn.io')
   })
 


### PR DESCRIPTION
Links:
- https://github.com/filcdn/roadmap/issues/31
