### PR TITLE
chore: Add proof-set id to retrieval logs

### DIFF
--- a/db/migrations/0009_add_proof_set_id_column.sql
+++ b/db/migrations/0009_add_proof_set_id_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE retrieval_logs ADD COLUMN proof_set_id TEXT;

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -110,6 +110,7 @@ export default {
         workerTtfb: null, // Will be populated later
       },
       requestCountryCode,
+      proofSetId,
     }
 
     if (!originResponse.body) {

--- a/retriever/lib/store.js
+++ b/retriever/lib/store.js
@@ -17,6 +17,8 @@ import { httpAssert } from './http-assert.js'
  * @param {string} params.timestamp - The timestamp of the retrieval.
  * @param {string | null} params.requestCountryCode - The country code where the
  *   request originated from
+ * @param {string} params.proofSetId - The proof set ID associated with the
+ *   retrieval
  * @returns {Promise<void>} - A promise that resolves when the log is inserted.
  */
 export async function logRetrievalResult(env, params) {
@@ -30,6 +32,7 @@ export async function logRetrievalResult(env, params) {
     timestamp,
     performanceStats,
     requestCountryCode,
+    proofSetId,
   } = params
 
   try {
@@ -45,9 +48,10 @@ export async function logRetrievalResult(env, params) {
         fetch_ttfb,
         fetch_ttlb,
         worker_ttfb,
-        request_country_code
+        request_country_code,
+        proof_set_id
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
     )
       .bind(
@@ -61,6 +65,7 @@ export async function logRetrievalResult(env, params) {
         performanceStats?.fetchTtlb ?? null,
         performanceStats?.workerTtfb ?? null,
         requestCountryCode,
+        proofSetId,
       )
       .run()
   } catch (error) {

--- a/retriever/test/store.test.js
+++ b/retriever/test/store.test.js
@@ -19,10 +19,20 @@ describe('logRetrievalResult', () => {
       responseStatus: 200,
       timestamp: new Date().toISOString(),
       requestCountryCode: 'US',
+      proofSetId: '1',
     })
 
     const readOutput = await env.DB.prepare(
-      `SELECT owner_address,client_address,response_status,egress_bytes,cache_miss,request_country_code FROM retrieval_logs WHERE owner_address = '${OWNER_ADDRESS}' AND client_address = '${CLIENT_ADDRESS}'`,
+      `SELECT 
+        owner_address,
+        client_address,
+        response_status,
+        egress_bytes,
+        cache_miss,
+        request_country_code,
+        proof_set_id 
+      FROM retrieval_logs 
+      WHERE owner_address = '${OWNER_ADDRESS}' AND client_address = '${CLIENT_ADDRESS}'`,
     ).all()
     const result = readOutput.results
     assert.deepStrictEqual(result, [
@@ -33,6 +43,7 @@ describe('logRetrievalResult', () => {
         egress_bytes: 1234,
         cache_miss: 0,
         request_country_code: 'US',
+        proof_set_id: '1',
       },
     ])
   })


### PR DESCRIPTION
This PR adds proof-set column to retrieval logs table. Introducing proof-set column to retrieval logs will enable us to track egress per proof-set and impose per proof-set egress quotas.

Related to https://github.com/filcdn/roadmap/issues/25