### PR TITLE
feat: Check if client is sanctioned on retrieval

### DIFF
--- a/retriever/lib/store.js
+++ b/retriever/lib/store.js
@@ -150,7 +150,6 @@ export async function getOwnerAndValidateClient(env, clientAddress, rootCid) {
   const withClientNotSanctioned = withPaymentRail.filter(
     (row) => !row.is_sanctioned,
   )
-  console.log(`With not sanctioned`, withClientNotSanctioned)
   httpAssert(
     withClientNotSanctioned.length > 0,
     403,

--- a/retriever/test/retriever.test.js
+++ b/retriever/test/retriever.test.js
@@ -79,7 +79,6 @@ describe('retriever.fetch', () => {
       })
       i++
     }
-    await withWalletDetails(env, defaultClientAddress, false)
   })
 
   it('redirects to https://filcdn.com when no CID was provided', async () => {

--- a/retriever/test/retriever.test.js
+++ b/retriever/test/retriever.test.js
@@ -11,6 +11,7 @@ import {
   withProofSetRoots,
   withApprovedProvider,
   withBadBits,
+  withWalletDetails,
 } from './test-data-builders.js'
 import { CONTENT_STORED_ON_CALIBRATION } from './test-data.js'
 
@@ -51,6 +52,7 @@ describe('retriever.fetch', () => {
       env.DB.prepare('DELETE FROM indexer_proof_sets'),
       env.DB.prepare('DELETE FROM indexer_proof_set_rails'),
       env.DB.prepare('DELETE FROM bad_bits'),
+      env.DB.prepare('DELETE FROM wallet_details'),
     ])
 
     let i = 1
@@ -77,6 +79,7 @@ describe('retriever.fetch', () => {
       })
       i++
     }
+    await withWalletDetails(env, defaultClientAddress, false)
   })
 
   it('redirects to https://filcdn.com when no CID was provided', async () => {
@@ -531,6 +534,35 @@ describe('retriever.fetch', () => {
     expect(await res.text()).toBe(
       'The requested CID was flagged by the Bad Bits Denylist at https://badbits.dwebops.pub',
     )
+  })
+
+  it('reject retrieval request if client is sanctioned', async () => {
+    const proofSetId = 'test-proof-set-client-sanctioned'
+    const railId = 'rail-proof-set-client-sanctioned'
+    const rootId = 'root-proof-set-client-sanctioned'
+    const rootCid =
+      'baga6ea4seaqaleibb6ud4xeemuzzpsyhl6cxlsymsnfco4cdjka5uzajo2x4ipa'
+    const owner = '0xOWNER'
+    const clientAddress = '0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E'
+    await withProofSetRoots(env, {
+      owner,
+      clientAddress,
+      rootCid,
+      proofSetId,
+      railId,
+      withCDN: true,
+      rootId,
+    })
+
+    await withWalletDetails(
+      env,
+      clientAddress,
+      true, // Sanctioned
+    )
+    const req = withRequest(clientAddress, rootCid, 'GET')
+    const res = await worker.fetch(req, env)
+
+    assert.strictEqual(res.status, 403)
   })
 })
 

--- a/retriever/test/test-data-builders.js
+++ b/retriever/test/test-data-builders.js
@@ -75,3 +75,22 @@ export async function withBadBits(env, ...cids) {
   const entries = await Promise.all(cids.map(getBadBitsEntry))
   await env.DB.batch(entries.map((it) => stmt.bind(it)))
 }
+
+/**
+ * Inserts an address into the database with an optional sanctioned flag.
+ *
+ * @param {Env} env
+ * @param {string} address
+ * @param {boolean} [isSanctioned=false] Default is `false`
+ * @returns {Promise<void>}
+ */
+export async function withWalletDetails(env, address, isSanctioned = false) {
+  await env.DB.prepare(
+    `
+    INSERT INTO wallet_details (address, is_sanctioned)
+    VALUES (?, ?)
+  `,
+  )
+    .bind(address.toLowerCase(), isSanctioned ? 1 : 0)
+    .run()
+}


### PR DESCRIPTION
This PR introduces check if client (user) wallet is sanctioned during retrieval. In case client wallet is sanctioned we return error response with status code 403.

Related: 
- https://github.com/filcdn/roadmap/issues/17
- https://github.com/filcdn/worker/pull/171
