### PR TITLE
fix don't alert on unactionable bad bits service error

### DIFF
--- a/bad-bits/lib/bad-bits.js
+++ b/bad-bits/lib/bad-bits.js
@@ -30,9 +30,11 @@ export async function fetchAndStoreBadBits(
   }
 
   if (!response.ok) {
-    throw new Error(
+    const error = new Error(
       `Failed to fetch bad bits: ${response.status} ${response.statusText}`,
     )
+    error.noAlert = response.status >= 500
+    throw error
   }
 
   const text = await response.text()

--- a/bad-bits/lib/bad-bits.js
+++ b/bad-bits/lib/bad-bits.js
@@ -33,7 +33,7 @@ export async function fetchAndStoreBadBits(
     const error = new Error(
       `Failed to fetch bad bits: ${response.status} ${response.statusText}`,
     )
-    error.noAlert = response.status >= 500
+    error.noAlert = response.status === 525
     throw error
   }
 


### PR DESCRIPTION
HTTP error 525 (ssl handshake failed) happens multiple times a day, and there's nothing we can do about it.

Once this is deployed, I'll update the alert condition to not create a Slack alert when `noAlert` is set.

Known risk of this PR: If Bad bits goes forever down, we won't notice.