### PR TITLE
feat: Track per proof set egress stats

### DIFF
--- a/db/migrations/0012_add_proof_set_stats.sql
+++ b/db/migrations/0012_add_proof_set_stats.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS proof_set_stats (
+  set_id TEXT PRIMARY KEY,
+  total_egress_bytes_used INTEGER NOT NULL DEFAULT 0
+);

--- a/retriever/bin/retriever.js
+++ b/retriever/bin/retriever.js
@@ -4,7 +4,11 @@ import {
   retrieveFile as defaultRetrieveFile,
   measureStreamedEgress,
 } from '../lib/retrieval.js'
-import { getOwnerAndValidateClient, logRetrievalResult } from '../lib/store.js'
+import {
+  getOwnerAndValidateClient,
+  logRetrievalResult,
+  updateProofSetSats,
+} from '../lib/store.js'
 import { httpAssert } from '../lib/http-assert.js'
 import { setContentSecurityPolicy } from '../lib/content-security-policy.js'
 import { findInBadBits } from '../lib/bad-bits-util.js'
@@ -135,6 +139,8 @@ export default {
             },
             proofSetId,
           })
+
+          await updateProofSetSats(env, { proofSetId, egressBytes })
         })(),
       )
 

--- a/retriever/lib/store.js
+++ b/retriever/lib/store.js
@@ -183,3 +183,21 @@ export async function getOwnerAndValidateClient(env, clientAddress, rootCid) {
 
   return { ownerAddress, pieceRetrievalUrl, proofSetId }
 }
+
+/**
+ * @param {Env} env - Worker environment (contains D1 binding).
+ * @param {object} params - Parameters for the proof set update.
+ * @param {string} params.proofSetId - The ID of the proof set to update.
+ * @param {number} params.egressBytes - The egress bytes used for the response.
+ */
+export async function updateProofSetSats(env, { proofSetId, egressBytes }) {
+  await env.DB.prepare(
+    `
+    INSERT INTO proof_set_stats (set_id, total_egress_bytes_used)
+    VALUES (?, ?)
+    ON CONFLICT(set_id) DO UPDATE SET total_egress_bytes_used = COALESCE(proof_set_stats.total_egress_bytes_used, 0) + excluded.total_egress_bytes_used
+    `,
+  )
+    .bind(proofSetId, egressBytes)
+    .run()
+}

--- a/retriever/test/store.test.js
+++ b/retriever/test/store.test.js
@@ -326,7 +326,7 @@ describe('getOwnerAndValidateClient', () => {
   })
 })
 
-describe('updateProofSetEgressStats', () => {
+describe('updateProofSetStats', () => {
   it('inserts and updates egress stats', async () => {
     const PROOF_SET_ID = 'test-proof-set-1'
     const EGRESS_BYTES = 123456

--- a/retriever/test/store.test.js
+++ b/retriever/test/store.test.js
@@ -1,11 +1,16 @@
 import { describe, it, beforeAll } from 'vitest'
 import assert from 'node:assert/strict'
-import { logRetrievalResult, getOwnerAndValidateClient } from '../lib/store.js'
+import {
+  logRetrievalResult,
+  getOwnerAndValidateClient,
+  updateProofSetSats,
+} from '../lib/store.js'
 import { env } from 'cloudflare:test'
 import {
   withProofSetRoots,
   withApprovedProvider,
 } from './test-data-builders.js'
+
 describe('logRetrievalResult', () => {
   it('inserts a log into local D1 via logRetrievalResult and verifies it', async () => {
     const OWNER_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
@@ -318,5 +323,53 @@ describe('getOwnerAndValidateClient', () => {
       ownerAddress: owner1.toLowerCase(),
       pieceRetrievalUrl: 'https://pdp-provider-1.xyz',
     })
+  })
+})
+
+describe('updateProofSetEgressStats', () => {
+  it('inserts and updates egress stats', async () => {
+    const PROOF_SET_ID = 'test-proof-set-1'
+    const EGRESS_BYTES = 123456
+
+    await updateProofSetSats(env, {
+      proofSetId: PROOF_SET_ID,
+      egressBytes: EGRESS_BYTES,
+    })
+
+    const { results: insertResults } = await env.DB.prepare(
+      `SELECT set_id, total_egress_bytes_used 
+       FROM proof_set_stats 
+       WHERE set_id = ?`,
+    )
+      .bind(PROOF_SET_ID)
+      .all()
+
+    assert.deepStrictEqual(insertResults, [
+      {
+        set_id: PROOF_SET_ID,
+        total_egress_bytes_used: EGRESS_BYTES,
+      },
+    ])
+
+    // Update the egress stats
+    await updateProofSetSats(env, {
+      proofSetId: PROOF_SET_ID,
+      egressBytes: 1000,
+    })
+
+    const { results: updateResults } = await env.DB.prepare(
+      `SELECT set_id, total_egress_bytes_used 
+       FROM proof_set_stats 
+       WHERE set_id = ?`,
+    )
+      .bind(PROOF_SET_ID)
+      .all()
+
+    assert.deepStrictEqual(updateResults, [
+      {
+        set_id: PROOF_SET_ID,
+        total_egress_bytes_used: EGRESS_BYTES + 1000,
+      },
+    ])
   })
 })


### PR DESCRIPTION
This pull request introduces functionality to track and update proof set stats. The changes include the creation of a new database table, an implementation of an update function, and corresponding tests to ensure correctness.

### Database Changes:
* Added a new table `proof_set_stats` to store data set stats with columns for `set_id` (primary key) and `total_egress_bytes_used` with a default value of 0 (`db/migrations/0012_add_proof_set_stats.sql`).

### Retriever:
* Implemented `updateProofSetSats` function in `retriever/lib/store.js` to insert or update stats in the `proof_set_stats` table. It uses an `INSERT ... ON CONFLICT` query to handle updates.

### Testing:
* Added tests for the `updateProofSetSats` function in `retriever/test/store.test.js` to validate both insertion and update scenarios. This ensures that the function correctly handles new entries and increments existing stats.


Closes https://github.com/filcdn/roadmap/issues/45