### PR TITLE
feat: add `wallet_details.last_screened_at`

### DIFF
--- a/db/migrations/0013_add_wallet_screened_at.sql
+++ b/db/migrations/0013_add_wallet_screened_at.sql
@@ -1,4 +1,4 @@
 ALTER TABLE wallet_details
-ADD COLUMN screened_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 0;
+ADD COLUMN last_screened_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 0;
 
-CREATE INDEX idx_wallet_details_screened_at ON wallet_details(screened_at);
+CREATE INDEX idx_wallet_details_last_screened_at ON wallet_details(last_screened_at);

--- a/db/migrations/0013_add_wallet_screened_at.sql
+++ b/db/migrations/0013_add_wallet_screened_at.sql
@@ -1,0 +1,4 @@
+ALTER TABLE wallet_details
+ADD COLUMN screened_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_wallet_details_screened_at ON wallet_details(screened_at);

--- a/db/migrations/0013_add_wallet_screened_at.sql
+++ b/db/migrations/0013_add_wallet_screened_at.sql
@@ -1,4 +1,4 @@
 ALTER TABLE wallet_details
-ADD COLUMN last_screened_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT 0;
+ADD COLUMN last_screened_at TIMESTAMP WITH TIME ZONE;
 
 CREATE INDEX idx_wallet_details_last_screened_at ON wallet_details(last_screened_at);

--- a/indexer/lib/proof-set-handler.js
+++ b/indexer/lib/proof-set-handler.js
@@ -27,11 +27,11 @@ export async function handleProofSetRailCreated(
 
     await env.DB.prepare(
       `
-      INSERT INTO wallet_details (address, is_sanctioned, screened_at)
+      INSERT INTO wallet_details (address, is_sanctioned, last_screened_at)
       VALUES (?, ?, datetime('now'))
       ON CONFLICT (address) DO UPDATE SET
         is_sanctioned = excluded.is_sanctioned,
-        screened_at = excluded.screened_at
+        last_screened_at = excluded.last_screened_at
       `,
     )
       .bind(payload.payer, isPayerSanctioned)

--- a/indexer/lib/proof-set-handler.js
+++ b/indexer/lib/proof-set-handler.js
@@ -27,9 +27,11 @@ export async function handleProofSetRailCreated(
 
     await env.DB.prepare(
       `
-        INSERT INTO wallet_details (address, is_sanctioned)
-        VALUES (?, ?)
-        ON CONFLICT (address) DO UPDATE SET is_sanctioned = excluded.is_sanctioned
+      INSERT INTO wallet_details (address, is_sanctioned, screened_at)
+      VALUES (?, ?, datetime('now'))
+      ON CONFLICT (address) DO UPDATE SET
+        is_sanctioned = excluded.is_sanctioned,
+        screened_at = excluded.screened_at
       `,
     )
       .bind(payload.payer, isPayerSanctioned)

--- a/indexer/test/indexer.test.js
+++ b/indexer/test/indexer.test.js
@@ -426,7 +426,7 @@ describe('retriever.indexer', () => {
 
       expect(walletDetails.length).toBe(1)
       expect(walletDetails[0].is_sanctioned).toBe(0)
-      assertCloseToNow(walletDetails[0].screened_at)
+      assertCloseToNow(walletDetails[0].last_screened_at)
     })
     it('does not insert duplicate proof set rails', async () => {
       const proofSetId = randomId()
@@ -629,13 +629,13 @@ describe('retriever.indexer', () => {
       expect(initialWalletDetails.length).toBe(1)
       expect(initialWalletDetails[0].address).toBe('0xPayerAddress')
       expect(initialWalletDetails[0].is_sanctioned).toBe(0)
-      assertCloseToNow(initialWalletDetails[0].screened_at)
+      assertCloseToNow(initialWalletDetails[0].last_screened_at)
 
       // When the wallet creates the second ProofSet some time later,
       // it's flagged as sanctioned
 
       await env.DB.exec(
-        'UPDATE wallet_details SET screened_at = datetime("now", "-1 day")',
+        'UPDATE wallet_details SET last_screened_at = datetime("now", "-1 day")',
       )
       mockCheckIfAddressIsSanctioned.mockResolvedValue(true)
       req = new Request('https://host/proof-set-rail-created', {
@@ -666,7 +666,7 @@ describe('retriever.indexer', () => {
       expect(walletDetails.length).toBe(1)
       expect(walletDetails[0].address).toBe('0xPayerAddress')
       expect(walletDetails[0].is_sanctioned).toBe(1)
-      assertCloseToNow(walletDetails[0].screened_at)
+      assertCloseToNow(walletDetails[0].last_screened_at)
     })
 
     it('sends message to queue if sanction check fails', async () => {


### PR DESCRIPTION
In preparation to periodically screen all wallets for sanctions, I am enhancing the current wallet management flow to record the time when we last performed sanction screening for each address. This will enable the on-schedule screening worker to pick wallet address based on how long they were not screened.

Links:
- https://github.com/filcdn/worker/issues/203
