### PR TITLE
fix: update provider filtering logic in getOwnerAndValidateClient function

### DIFF
--- a/retriever/lib/store.js
+++ b/retriever/lib/store.js
@@ -161,7 +161,7 @@ export async function getOwnerAndValidateClient(env, clientAddress, rootCid) {
     `Wallet '${clientAddress}' is sanctioned and cannot retrieve root_cid '${rootCid}'.`,
   )
 
-  const withApprovedProvider = withCDN.filter((row) => row.piece_retrieval_url)
+  const withApprovedProvider = withClientNotSanctioned.filter((row) => row.piece_retrieval_url)
   httpAssert(
     withApprovedProvider.length > 0,
     404,


### PR DESCRIPTION
Replaced the use of withCDN with withClientNotSanctioned for filtering approved providers in the getOwnerAndValidateClient function to ensure only non-sanctioned clients are considered.

Closes #256