### PR TITLE
fix: new payload format for PiecesAdded webhook

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "assert-ok-response": "^1.0.0",
+    "multiformats": "^13.4.0",
     "validator": "^13.15.15"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "version": "1.0.0",
       "dependencies": {
         "assert-ok-response": "^1.0.0",
+        "multiformats": "^13.4.0",
         "validator": "^13.15.15"
       },
       "devDependencies": {
@@ -5820,6 +5821,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.0.tgz",
+      "integrity": "sha512-Mkb/QcclrJxKC+vrcIFl297h52QcKh2Az/9A5vbWytbQt4225UWWWmIuSsKksdww9NkIeYcA7DkfftyLuC/JSg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",


### PR DESCRIPTION
- `piece_ids` is an array of strings
- `piece_cids` is an array of hex-encoded CIDs

Example payload as recorded by https://webhook.site/#!/view/a2b33dc4-8d98-4dd1-b126-d91bfec210d5:

```json
{
  "vid": 12840839818510436,
  "block": 2989741,
  "id": "N732Ksr6gx1gmqECUpL8Q2bvJtUHPz+2nmkgGFMnu2MJAAAA",
  "set_id": "4",
  "piece_ids": [
    "6"
  ],
  "piece_cids": [
    "0x0155912024e6d3040eaa8626231b30502cb032a2da493892672e78b3d3c745f64ed0e4bb9dc856b813"
  ],
  "block_number": 2989741,
  "block_timestamp": 1757018610,
  "transaction_hash": "N732Ksr6gx1gmqECUpL8Q2bvJtUHPz+2nmkgGFMnu2M=",
  "_gs_chain": "filecoin-testnet",
  "_gs_gid": "344c78e2759553a495ec4c8493b3d69e"
}
```

Links:
- https://github.com/filcdn/roadmap/issues/59
