### PR TITLE
fix: db deployment scripts

### DIFF
--- a/db/deploy-calibration.sh
+++ b/db/deploy-calibration.sh
@@ -6,7 +6,10 @@ cd "$(dirname "$(readlink -f "$0")")"
 # Add monorepo's node_modules to the PATH
 PATH=../node_modules/.bin:$PATH
 
-if ! wrangler d1 list | grep -q filcdn-db; then
-  wrangler d1 create filcdn-db --env calibration
+DB=filcdn-calibration-db
+ENV=calibration
+
+if ! wrangler d1 list | grep -q "$DB"; then
+  wrangler d1 create "$DB" --env "$ENV"
 fi
-wrangler d1 migrations apply filcdn-db --remote --env calibration
+wrangler d1 migrations apply "$DB" --remote --env "$ENV"

--- a/db/deploy-mainnet.sh
+++ b/db/deploy-mainnet.sh
@@ -6,7 +6,10 @@ cd "$(dirname "$(readlink -f "$0")")"
 # Add monorepo's node_modules to the PATH
 PATH=../node_modules/.bin:$PATH
 
-if ! wrangler d1 list --env mainnet | grep -q filcdn-mainnet-db; then
-  wrangler d1 create filcdn-mainnet-db --env mainnet
+DB=filcdn-mainnet-db
+ENV=mainnet
+
+if ! wrangler d1 list | grep -q "$DB"; then
+  wrangler d1 create "$DB" --env "$ENV"
 fi
-wrangler d1 migrations apply filcdn-mainnet-db --remote --env mainnet
+wrangler d1 migrations apply "$DB" --remote --env "$ENV"


### PR DESCRIPTION
- fix the calibration DB name
- refactor the code - extract config into variables to avoid repetition

Output from the fixed script:

```
❯ ./db/deploy-calibration.sh

 ⛅️ wrangler 4.33.1 (update available 4.34.0)
─────────────────────────────────────────────
Migrations to be applied:
┌────────────────────────┐
│ name                   │
├────────────────────────┤
│ 0014_m2_5_upgrades.sql │
└────────────────────────┘
? About to apply 1 migration(s)
Your database may not be available to serve requests during the migration, continue? › (Y/n)
```
