### PR TITLE
Fix: Pass account terminator to tx calls

### DIFF
--- a/terminator/lib/chain.js
+++ b/terminator/lib/chain.js
@@ -8,7 +8,6 @@ import { filecoinCalibration, filecoin } from 'viem/chains'
  *   RPC_URL: string
  *   FILCDN_CONTROLLER_ADDRESS_PRIVATE_KEY: string
  * }} env
- * @returns
  */
 export function getChainClient(env) {
   const chain = env.ENVIRONMENT === 'mainnet' ? filecoin : filecoinCalibration
@@ -27,5 +26,5 @@ export function getChainClient(env) {
     account,
   })
 
-  return { publicClient, walletClient }
+  return { publicClient, walletClient, account }
 }

--- a/terminator/lib/queue-handlers.js
+++ b/terminator/lib/queue-handlers.js
@@ -49,11 +49,11 @@ export async function handleTerminateCdnServiceQueueMessage(
   )
 
   try {
-    // Get contract instance
-    const { walletClient, publicClient } = getChainClient(env)
+    const { walletClient, publicClient, account } = getChainClient(env)
 
     // Create contract call
     const { request } = await publicClient.simulateContract({
+      account,
       abi: fwssAbi,
       address: env.FILECOIN_WARM_STORAGE_SERVICE_ADDRESS,
       functionName: 'terminateCDNService',
@@ -117,7 +117,7 @@ export async function handleTransactionRetryQueueMessage(
   console.log(`Processing transaction retry for hash: ${transactionHash}`)
 
   try {
-    const { publicClient, walletClient } = getChainClient(env)
+    const { publicClient, walletClient, account } = getChainClient(env)
 
     // First check if the original transaction is still pending
     try {
@@ -171,6 +171,7 @@ export async function handleTransactionRetryQueueMessage(
 
     // Replace the transaction by sending a new one with the same nonce but higher gas fees
     const retryHash = await walletClient.sendTransaction({
+      account,
       to: originalTx.to,
       nonce: originalTx.nonce,
       value: originalTx.value,

--- a/terminator/test/chain.test.js
+++ b/terminator/test/chain.test.js
@@ -9,12 +9,14 @@ describe('getChainClient', () => {
       FILECOIN_WARM_STORAGE_SERVICE_ADDRESS:
         '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
       FILCDN_CONTROLLER_ADDRESS_PRIVATE_KEY:
-        '0x4c0883a69102937d6231471b5dbb6204fe5129617082796fbc48dfcb573d7e0c',
+        '0xdead000000000000000000000000000000000000000000000000000000000000',
     }
 
-    const { walletClient, publicClient } = getChainClient(env)
+    const { walletClient, publicClient, account } = getChainClient(env)
     expect(walletClient).toBeDefined()
     expect(publicClient).toBeDefined()
+    expect(account).toBeDefined()
+    expect(account.address).toBe('0xe1AB69E519d887765cF0bb51D0cFFF2264B38080')
     const chainId = await publicClient.getChainId()
     expect(chainId).toBe(314)
   })
@@ -26,12 +28,14 @@ describe('getChainClient', () => {
       FILECOIN_WARM_STORAGE_SERVICE_ADDRESS:
         '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
       FILCDN_CONTROLLER_ADDRESS_PRIVATE_KEY:
-        '0x4c0883a69102937d6231471b5dbb6204fe5129617082796fbc48dfcb573d7e0c',
+        '0xdead000000000000000000000000000000000000000000000000000000000000',
     }
 
-    const { walletClient, publicClient } = getChainClient(env)
+    const { walletClient, publicClient, account } = getChainClient(env)
     expect(walletClient).toBeDefined()
     expect(publicClient).toBeDefined()
+    expect(account).toBeDefined()
+    expect(account.address).toBe('0xe1AB69E519d887765cF0bb51D0cFFF2264B38080')
     const chainId = await publicClient.getChainId()
     expect(chainId).toBe(314159)
   })
@@ -43,12 +47,14 @@ describe('getChainClient', () => {
       FILECOIN_WARM_STORAGE_SERVICE_ADDRESS:
         '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
       FILCDN_CONTROLLER_ADDRESS_PRIVATE_KEY:
-        '0x4c0883a69102937d6231471b5dbb6204fe5129617082796fbc48dfcb573d7e0c',
+        '0xdead000000000000000000000000000000000000000000000000000000000000',
     }
 
-    const { walletClient, publicClient } = getChainClient(env)
+    const { walletClient, publicClient, account } = getChainClient(env)
     expect(walletClient).toBeDefined()
     expect(publicClient).toBeDefined()
+    expect(account).toBeDefined()
+    expect(account.address).toBe('0xe1AB69E519d887765cF0bb51D0cFFF2264B38080')
     const chainId = await publicClient.getChainId()
     expect(chainId).toBe(314159)
   })

--- a/terminator/test/queue-handlers.test.js
+++ b/terminator/test/queue-handlers.test.js
@@ -6,6 +6,7 @@ import {
 import { env } from 'cloudflare:test'
 import { abi as fwssAbi } from '../lib/fwss.js'
 import { randomId, withDataSet } from './test-helpers.js'
+import { privateKeyToAccount } from 'viem/accounts'
 
 // Test fixtures and helpers
 const createMockEnv = (env) => ({
@@ -21,6 +22,10 @@ const createMockEnv = (env) => ({
     send: vi.fn().mockResolvedValue(undefined),
   },
 })
+
+const mockAccount = privateKeyToAccount(
+  '0xdead000000000000000000000000000000000000000000000000000000000000',
+)
 
 const createMockChainClient = (env) => ({
   walletClient: {
@@ -43,6 +48,7 @@ const createMockChainClient = (env) => ({
       value: '1000000000000000000',
     }),
   },
+  account: mockAccount,
 })
 
 describe('handleTerminateCdnServiceQueueMessage', () => {
@@ -85,6 +91,7 @@ describe('handleTerminateCdnServiceQueueMessage', () => {
     ])
 
     expect(mockChainClient.publicClient.simulateContract).toHaveBeenCalledWith({
+      account: mockAccount,
       address: '0xcontract',
       abi: fwssAbi,
       functionName: 'terminateCDNService',
@@ -226,6 +233,7 @@ describe('handleTransactionRetryQueueMessage', () => {
 
       expect(mockChainClient.walletClient.sendTransaction).toHaveBeenCalledWith(
         {
+          account: mockAccount,
           to: '0xcontract',
           value: 0n,
           nonce: 42,
@@ -283,6 +291,7 @@ describe('handleTransactionRetryQueueMessage', () => {
 
       expect(mockChainClient.walletClient.sendTransaction).toHaveBeenCalledWith(
         {
+          account: mockAccount,
           to: '0xcontract',
           value: 0n,
           nonce: 42,


### PR DESCRIPTION
Pass `account` returned by `getChainClient` to transaction calls. 